### PR TITLE
Allow some addresses to have zero transactions without skipping balances

### DIFF
--- a/lib/api/api.js
+++ b/lib/api/api.js
@@ -775,6 +775,7 @@ api.prototype.getNewAddress = function(seed, options, callback) {
     //
     else {
 
+        var howManyZerosInARow = 0;
         async.doWhilst(function(callback) {
             // Iteratee function
 
@@ -798,8 +799,21 @@ api.prototype.getNewAddress = function(seed, options, callback) {
             // Increase the index
             index += 1;
 
+            // Sometimes addresses are skipped, resulting in zero transactions
+            // Wait until we've seen five in a row that are empty before calling it quits.
+            if (transactions.hashes.length === 0) {
+                howManyZerosInARow++;
+            } else {
+                howManyZerosInARow = 0;
+            }
+
+            if (howManyZerosInARow === 5) {
+                // We are done.  Slice off the last five addresses.
+                allAddresses = allAddresses.slice(0, -5);
+            }
+
             // Validity check
-            return transactions.hashes.length > 0;
+            return howManyZerosInARow < 5;
         }, function(err, address) {
             // Final callback
 

--- a/lib/api/api.js
+++ b/lib/api/api.js
@@ -817,9 +817,9 @@ api.prototype.getNewAddress = function(seed, options, callback) {
             }
 
             // Validity check
-            if (howManyZerosInARow === 5) {
-                // We are done.  Slice off the last four addresseses, leaving the last empty one
-                allAddresses = allAddresses.slice(0, -4);
+            if (howManyZerosInARow === 2) {
+                // We are done.  Slice off some addresseses, leaving the last empty one
+                allAddresses = allAddresses.slice(0, -1);
                 return false;
             }
 

--- a/lib/api/api.js
+++ b/lib/api/api.js
@@ -807,13 +807,14 @@ api.prototype.getNewAddress = function(seed, options, callback) {
                 howManyZerosInARow = 0;
             }
 
+            // Validity check
             if (howManyZerosInARow === 5) {
-                // We are done.  Slice off the last five addresses.
-                allAddresses = allAddresses.slice(0, -5);
+                // We are done.  Slice off the last four addresseses, leaving the last empty one
+                allAddresses = allAddresses.slice(0, -4);
+                return false;
             }
 
-            // Validity check
-            return howManyZerosInARow < 5;
+            return true;
         }, function(err, address) {
             // Final callback
 

--- a/lib/api/api.js
+++ b/lib/api/api.js
@@ -776,6 +776,7 @@ api.prototype.getNewAddress = function(seed, options, callback) {
     else {
 
         var howManyZerosInARow = 0;
+        var firstEmptyAddress;
         async.doWhilst(function(callback) {
             // Iteratee function
 
@@ -791,6 +792,14 @@ api.prototype.getNewAddress = function(seed, options, callback) {
 
         }, function(address, transactions) {
             // Test function with validity check
+
+            if (!firstEmptyAddress && transactions.hashes.length === 0) {
+              firstEmptyAddress = address;
+              if (!options.returnAll) {
+                // All we need is this address, so no more work is done.
+                return false;
+              }
+            }
 
             if (options.returnAll) {
                 allAddresses.push(address)
@@ -823,8 +832,8 @@ api.prototype.getNewAddress = function(seed, options, callback) {
             } else {
 
                 // If returnAll, return list of allAddresses
-                // else return the last address that was generated
-                var addressToReturn = options.returnAll ? allAddresses : address;
+                // else return the first address found without any transactions
+                var addressToReturn = options.returnAll ? allAddresses : firstEmptyAddress;
 
                 return callback(null, addressToReturn);
             }


### PR DESCRIPTION
TL;DR sometimes balances mysteriously disappear if an address has somehow been skipped.  We need to allow for a little bit of this when calculating balances, otherwise balances end up on addresses further down the chain and disappear until that address comes up in operation.

----------

Another thing I noticed when working on the cli was that my balance on a test seed suddenly disappeared.  This was troubling to say the least. :)  I looked at the transaction history and I could see no reason for it.  A last transaction moved a small amount of iota out to another seed's address, and then banked the remainder in a new address.  After that, the banked iota just disappeared.

In determining the reason for this I determined that the address the iota was sent to, while valid for the seed, was not showing up in the list of addresses used in determining the account balance.  I tracked that down to some code in `getNewAddress`.

The logic in that function that enumerates addresses in use stops immediately when it finds an address without transactions.  However, in practice it turns out that occasionally addresses will get skipped.  Because of this the address enumeration often stops too soon, and skips valid addresses with actual balances.

I'm not sure my fix here is a perfect one, but what I found was that while enumerating addresses once I'd seen about five go past with zero transactions, that signaled the end of the actively used addresses.  It may not be a perfect fix, but it seems likely to work better in practice than the current logic.