### PR TITLE
Added validation on fromTrytes

### DIFF
--- a/lib/utils/asciiToTrytes.js
+++ b/lib/utils/asciiToTrytes.js
@@ -70,6 +70,9 @@ function fromTrytes(inputTrytes) {
     // If input is not a string, return null
     if ( typeof inputTrytes !== 'string' ) return null
 
+	// If input length is odd, trim last char
+    if (inputTrytes.length % 2) inputTrytes = inputTrytes.substring(0, inputTrytes.length-1)
+
     var TRYTE_VALUES = "9ABCDEFGHIJKLMNOPQRSTUVWXYZ";
     var outputString = "";
 

--- a/lib/utils/asciiToTrytes.js
+++ b/lib/utils/asciiToTrytes.js
@@ -70,7 +70,7 @@ function fromTrytes(inputTrytes) {
     // If input is not a string, return null
     if ( typeof inputTrytes !== 'string' ) return null
 
-	// If input length is odd, trim last char
+    // If input length is odd, trim last char
     if (inputTrytes.length % 2) inputTrytes = inputTrytes.substring(0, inputTrytes.length-1)
 
     var TRYTE_VALUES = "9ABCDEFGHIJKLMNOPQRSTUVWXYZ";

--- a/lib/utils/asciiToTrytes.js
+++ b/lib/utils/asciiToTrytes.js
@@ -70,8 +70,8 @@ function fromTrytes(inputTrytes) {
     // If input is not a string, return null
     if ( typeof inputTrytes !== 'string' ) return null
 
-    // If input length is odd, trim last char
-    if (inputTrytes.length % 2) inputTrytes = inputTrytes.substring(0, inputTrytes.length-1)
+    // If input length is odd, return null
+    if ( inputTrytes.length % 2 ) return null
 
     var TRYTE_VALUES = "9ABCDEFGHIJKLMNOPQRSTUVWXYZ";
     var outputString = "";


### PR DESCRIPTION
Since we are decoding in pairs, the length should be even. If odd, trailing 9 should be trimmed to avoid calculating an erroneous pair or an error should be returned.

Example 1
`toTrytes('A') = 'KB'`, adding trailing ’9’s to make 3 trytes: `'KB9'`.
`fromTrytes('KB9') = 'A￥'` which has a string length of `2`.
Meaning ascii chars: `65` + `65509` which is not correct.
Expected value is `A`, string length of `1`.

Example 2
`toTrytes('A') = 'KB'`, adding trailing ’9’s to make 5 trytes: `'KB999'`.
`fromTrytes('KB999') = 'A￥'` which has a string length of `3`.
Meaning ascii chars: `65` + `0` + `65509` which is not correct.
Expected value is `A`, string length of `2`.
 _Here we added 3 trailing `9`s to account for a null character that is not printable. Since a user might want to include it, it is a valid character so this function should NOT trim ALL trailing 9, unless this behavior is defined in the specification._

Solution
Return `null` if the length of `inputTrytes` is odd.