### PR TITLE
Use generic node URI in multisig example.

### DIFF
--- a/examples/multisig.js
+++ b/examples/multisig.js
@@ -1,7 +1,7 @@
 var IOTA = require('../lib/iota');
 
 var iota = new IOTA({
-    'host': 'http://85.93.93.110',
+    'host': 'http://localhost',
     'port': 14265
 });
 


### PR DESCRIPTION
Changed the node URI in `examples/multisig.js` to `localhost` so that it's clearer that this is a generic example.