### PR TITLE
Fix padding 'tags' hashes in findTransactions

### DIFF
--- a/lib/api/api.js
+++ b/lib/api/api.js
@@ -101,22 +101,19 @@ api.prototype.findTransactions = function(searchValues, callback) {
         // If tags, append to 27 trytes
         if (key === 'tags') {
 
-            hashes.forEach(function(hash) {
+            searchValues.tags = hashes.map(function(hash) {
 
                 // Simple padding to 27 trytes
                 while (hash.length < 27) {
-                    hash += '9'
+                    hash += '9';
                 }
 
-                // validate hashes
+                // validate hash
                 if (!inputValidator.isTrytes(hash, 27)) {
-
                     return callback(errors.invalidTrytes());
                 }
+                return hash;
             })
-
-            // Reassign padded tags so that it can be used for findTransactions
-            searchValues[key] = hashes;
         } else {
 
             // Check if correct array of hashes


### PR DESCRIPTION
Currently `findTransactions` doesn't work with `tags` because the padding of the hashes is broken. This change fixes that by correctly assigning modified hashes to the `searchValues` query object.