### PR TITLE
Consolidate settings code

### DIFF
--- a/lib/iota.js
+++ b/lib/iota.js
@@ -5,7 +5,17 @@ var Multisig = require('./multisig/multisig');
 
 
 function IOTA(settings) {
+    this.setSettings(settings);
+}
 
+
+/**
+*   Reset the libraries settings and internal objects
+*
+*   @method setSettings
+*   @param {Object} settings
+**/
+IOTA.prototype.setSettings = function(settings) {
     // IF NO SETTINGS, SET DEFAULT TO localhost:14265
     settings = settings || {};
     this.version = require('../package.json').version;
@@ -16,7 +26,6 @@ function IOTA(settings) {
     this.token = settings.token || false;
 
     if (this.sandbox) {
-
         // remove backslash character
         this.sandbox = this.provider.replace(/\/$/, '');
         this.provider = this.sandbox + '/commands';
@@ -29,8 +38,7 @@ function IOTA(settings) {
     this.utils = utils;
     this.valid = require("./utils/inputValidator");
     this.multisig = new Multisig(this._makeRequest);
-}
-
+};
 
 
 /**
@@ -40,13 +48,7 @@ function IOTA(settings) {
 *   @param {Object} settings
 **/
 IOTA.prototype.changeNode = function(settings) {
-
-    settings = settings || {};
-    this.host = settings.host ? settings.host : "http://localhost";
-    this.port = settings.port ? settings.port : 14265;
-    this.provider = settings.provider || this.host + ":" + this.port;
-
-    this._makeRequest.setProvider(this.provider);
+    this.setSettings(settings);
 };
 
 module.exports = IOTA;

--- a/lib/iota.js
+++ b/lib/iota.js
@@ -42,7 +42,7 @@ IOTA.prototype.setSettings = function(settings) {
 
 
 /**
-*   Change the Node the user connects to (won't work with sandbox)
+*   Change the Node the user connects to
 *
 *   @method changeNode
 *   @param {Object} settings


### PR DESCRIPTION
I need to make sure I can change the token from node to node as I change them, but currently the only place where the token is set is when the IOTA object is created.  

I noticed that there was a lot of duplicated code in the IOTA setup and the `changeNode` function, but `changeNode` wasn't keeping up with the main IOTA function.  I've refactored the setup code into a new `setSettings` function that can be shared by the main iota setup, and the `changeNode` function.

This simplifies the code and allows you to change all necessary settings when changing nodes.