### PR TITLE
multisig: remove checksum from addresses,  update example

### DIFF
--- a/examples/multisig.js
+++ b/examples/multisig.js
@@ -1,9 +1,6 @@
 var IOTA = require('../lib/iota');
 
-var iota = new IOTA({
-    'host': 'http://iota.bitfinex.com',
-    'port': 80
-});
+var iota = new IOTA();
 
 // First co-signer uses index 0 and security level 3
 var digestOne = iota.multisig.getDigest('ABCDFG', 0, 3);

--- a/examples/multisig.js
+++ b/examples/multisig.js
@@ -1,8 +1,8 @@
 var IOTA = require('../lib/iota');
 
 var iota = new IOTA({
-    'host': 'http://localhost',
-    'port': 14700
+    'host': 'http://iota.bitfinex.com',
+    'port': 80
 });
 
 // First co-signer uses index 0 and security level 3
@@ -43,13 +43,20 @@ console.log("IS VALID MULTISIG ADDRESS:", isValid);
 //
 //  When it comes to defining the remainder address, you have to generate that address before making a transfer
 //  Important to know here is the total sum of the security levels used by the cosigners.
+
+var input = {
+  'address': address,
+  'securitySum': 6,
+  'balance': 999
+}
+
 var multisigTransfer = [
   {'address': 'ZGHXPZYDKXPEOSQTAQOIXEEI9K9YKFKCWKYYTYAUWXK9QZAVMJXWAIZABOXHHNNBJIEBEUQRTBWGLYMTX', 'value': 999}
 ];
 // Define remainder address
 var remainderAddress = 'NZRALDYNVGJWUVLKDWFKJVNYLWQGCWYCURJIIZRLJIKSAIVZSGEYKTZRDBGJLOA9AWYJQB9IPWRAKUC9FBDRZJZXZG';
 
-iota.multisig.initiateTransfer(6, address, remainderAddress, multisigTransfer, function(e, initiatedBundle) {
+iota.multisig.initiateTransfer(input, remainderAddress, multisigTransfer, function(e, initiatedBundle) {
 
     if (e) {
         console.log(e);

--- a/lib/multisig/multisig.js
+++ b/lib/multisig/multisig.js
@@ -73,7 +73,7 @@ Multisig.prototype.validateAddress = function(multisigAddress, digests) {
     kerl.squeeze(addressTrits, 0, kerl.HASH_LENGTH);
 
     // Convert trits into trytes and return the address
-    return Converter.trytes(addressTrits) === multisigAddress;
+    return Converter.trytes(addressTrits) === Utils.noChecksum(multisigAddress);
 }
 
 
@@ -224,7 +224,7 @@ Multisig.prototype.initiateTransfer = function(input, remainderAddress, transfer
                     return callback(new Error("No remainder address defined"));
                 }
 
-                bundle.addEntry(1, remainderAddress, remainder, tag, timestamp);
+                bundle.addEntry(1, Utils.noChecksum(remainderAddress), remainder, tag, timestamp);
             }
 
             bundle.finalize();
@@ -278,6 +278,8 @@ Multisig.prototype.addSignature = function(bundleToSign, inputAddress, key, call
     // convert private key trytes into trits
     var key = Converter.trits(key);
 
+    // Remove checksum, if any
+    inputAddress = Utils.noChecksum(inputAddress);
 
     // First get the total number of already signed transactions
     // use that for the bundle hash calculation as well as knowing


### PR DESCRIPTION
- Remove any checksum from addresses in multisig
- Update multisig example to work with updated `initiateTransfer()`