### PR TITLE
multisig: fix type error

### DIFF
--- a/lib/multisig/multisig.js
+++ b/lib/multisig/multisig.js
@@ -233,7 +233,7 @@ Multisig.prototype.initiateTransfer = function(input, remainderAddress, transfer
             return callback(null, bundle.bundle);
         };
 
-        if(typeof input.balance !== undefined) {
+        if (input.balance) {
           createBundle(input.balance, callback);
         } else {
           var command = {


### PR DESCRIPTION
typeof returns a string, not types. simplify to a check for falsy
values, so people can also do things like: `balance: null`.

fixes #67