### PR TITLE
validation: handle invalid bundles

### DIFF
--- a/lib/crypto/signing/signing.js
+++ b/lib/crypto/signing/signing.js
@@ -3,6 +3,7 @@ var Converter = require("../converter/converter");
 var Bundle = require("../bundle/bundle");
 var add = require("../helpers/adder");
 var oldSigning = require("./oldSigning");
+var errors = require("../../errors/inputErrors");
 
 /**
 *           Signing related functions
@@ -170,6 +171,9 @@ var signatureFragment = function(normalizedBundleFragment, keyFragment) {
 *
 **/
 var validateSignatures = function(expectedAddress, signatureFragments, bundleHash) {
+    if (!bundleHash) {
+        throw errors.invalidBundleHash();
+    }
 
     var self = this;
     var bundle = new Bundle();

--- a/lib/utils/utils.js
+++ b/lib/utils/utils.js
@@ -341,6 +341,10 @@ var validateSignatures = function(signedBundle, inputAddress) {
         }
     }
 
+    if (!bundleHash) {
+        return false;
+    }
+
     return Signing.validateSignatures(inputAddress, signatureFragments, bundleHash);
 }
 


### PR DESCRIPTION
return false in case no matching bundle is found for the current
address. before it was throwing as the passed value to
`validateSignatures` in `crypto/signing.js` was `undefined`