### PR TITLE
Fixes issue #71

### DIFF
--- a/lib/utils/inputValidator.js
+++ b/lib/utils/inputValidator.js
@@ -8,6 +8,10 @@
 var isAddress = function(address) {
     // TODO: In the future check checksum
 
+    if (!isString(address)) {
+        return false;
+    }
+
     // Check if address with checksum
     if (address.length === 90) {
 
@@ -39,7 +43,7 @@ var isTrytes = function(trytes, length) {
     if (!length) length = "0,"
 
     var regexTrytes = new RegExp("^[9A-Z]{" + length +"}$");
-    return regexTrytes.test(trytes) && isString(trytes);
+    return isString(trytes) && regexTrytes.test(trytes);
 }
 
 /**
@@ -52,7 +56,7 @@ var isTrytes = function(trytes, length) {
 **/
 var isNinesTrytes = function(trytes) {
 
-    return /^[9]+$/.test(trytes) && isString(trytes);
+    return isString(trytes) && /^[9]+$/.test(trytes);
 }
 
 /**


### PR DESCRIPTION
Input validator `isAddress(address)` now checks `isString(address)`.
Also, `regex.test(<something>) && isString(<something>)`,
swapped to `isString(<something>) && regex.test(<something>)`,
for correct short-circuit evaluation, although I don't thing the isString is needed at all there,
(regex.test does that internally).