### PR TITLE
Feature: Add support for promises

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,26 @@ iota.api.getNodeInfo(function(error, success) {
 })
 ```
 
----
+You can also use promises in preference to callbacks, all promise versions of the callback functions have "Async" appended to the function name.
+
+Here is a simple example of how to use the promise version of the `getNodeInfo` function, called `getNodeInfoAsync`. This example produces the same result as the previous example:
+
+```
+iota.api.getNodeInfoAsync()
+    .then(console.log, console.error)
+```
+
+This also allows you to use the new ES8 `await` and `async` features. Shown in this short example:
+
+```
+try {
+    var info = await iota.api.getNodeInfoAsync();
+    ...
+} catch (err) {
+    console.error(err)
+}
+```
+
 
 ## API Table of Contents		
 

--- a/lib/api/api.js
+++ b/lib/api/api.js
@@ -1857,4 +1857,24 @@ api.prototype.isReattachable = function(inputAddresses, callback) {
     })
 }
 
+Object.keys(api.prototype).forEach(function(funcName) {
+    api.prototype[funcName + 'Async'] = promisify(api.prototype[funcName]);
+
+    function promisify(func) {
+        return function () {
+            var self = this;
+            var args = Array.prototype.slice.apply(arguments);
+            return new Promise(function (resolve, reject) {
+                func.apply(self, args.concat(function (err, value) {
+                    if (err) {
+                        reject(err);
+                    } else {
+                        resolve(value);
+                    }
+                }))
+            })
+        }
+    }
+})
+
 module.exports = api;


### PR DESCRIPTION
Added support for promises and async/await to callback functions. Added examples and explanation to readme.
The api callback functions now have a promise based variant with the same function name appended by "Async". 



