### PR TITLE
Fix for "invalid transfers object" error.

### DIFF
--- a/lib/utils/utils.js
+++ b/lib/utils/utils.js
@@ -54,7 +54,7 @@ var convertUnits = function(value, fromUnit, toUnit) {
 
     var floatValue = parseFloat(value);
 
-    var converted = (floatValue * unitMap[fromUnit]) / unitMap[toUnit];
+    var converted = parseInt((floatValue * unitMap[fromUnit]) / unitMap[toUnit]);
 
     return converted;
 }


### PR DESCRIPTION
convertUnits() should return an integer. But some amounts return a float (like 2.019 Mi results in 2019000.0000000002) which leads to the "invalid transfers object" error. Here I propose a simple fix for it by forcing an integer value as return.