### PR TITLE
fixing undefined variable in `getTransactionsObjects` function

### DIFF
--- a/lib/api/api.js
+++ b/lib/api/api.js
@@ -387,7 +387,7 @@ api.prototype.getTransactionsObjects = function(hashes, callback) {
 
             // If no trytes returned, simply push null as placeholder
             if (!thisTrytes) {
-                transactionObject.push(null);
+                transactionObjects.push(null);
             } else {
                 transactionObjects.push(Utils.transactionObject(thisTrytes));
             }


### PR DESCRIPTION
We push `null` placeholder in case we do not get tryte. The array we push to is not defined. Fixing it to use defined array so that index of hash & null tryte matches perfectly.