### PR TITLE
[fix] crypto/converter: Use an alternative approach to copy array buffer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@ node_modules
 bower_modules
 .DS_Store
 */**/.DS_Store
+
+## idea
+.idea
+*.iml

--- a/lib/crypto/converter/words.js
+++ b/lib/crypto/converter/words.js
@@ -17,22 +17,29 @@ var HALF_3 = new Uint32Array([
     0x5e69ebef
 ]);
 
+var clone_uint32Array = function(sourceArray) {
+  var destination = new ArrayBuffer(sourceArray.byteLength);
+  new Uint32Array(destination).set(new Uint32Array(sourceArray));
+
+  return destination;
+};
+
 var ta_reverse = function(array) {
-    if (array.reverse !== undefined) {
-        array.reverse();
-        return;
-    }
+  if (array.reverse !== undefined) {
+    array.reverse();
+    return;
+  }
 
-    var i = 0,
-        n = array.length,
-        middle = Math.floor(n / 2),
-        temp = null;
+  var i = 0,
+    n = array.length,
+    middle = Math.floor(n / 2),
+    temp = null;
 
-    for (; i < middle; i += 1) {
-        temp = array[i];
-        array[i] = array[n - 1 - i];
-        array[n - 1 - i] = temp;
-    }
+  for (; i < middle; i += 1) {
+    temp = array[i];
+    array[i] = array[n - 1 - i];
+    array[n - 1 - i] = temp;
+  }
 };
 
 /// negates the (unsigned) input array
@@ -156,7 +163,7 @@ var words_to_trits = function(words) {
         } else {
             /// bigint is between (unsigned) HALF_3 and (2**384 - 3**242/2).
             bigint_add_small(base, 1);
-            var tmp = HALF_3.slice(0);
+            var tmp = clone_uint32Array(HALF_3);
             bigint_sub(tmp, base);
             base = tmp;
         }
@@ -210,7 +217,7 @@ var trits_to_words = function(trits) {
     if (trits.slice(0, 242).every(function(a) {
             a == -1
         })) {
-        base = HALF_3.slice(0);
+        base = clone_uint32Array(HALF_3);
         bigint_not(base);
         bigint_add_small(base, 1);
     } else {
@@ -254,7 +261,7 @@ var trits_to_words = function(trits) {
                 // so we need to transform it to a two's complement representation
                 // of (base - HALF_3).
                 // as we don't have a wrapping (-), we need to use some bit magic
-                var tmp = HALF_3.slice(0);
+                var tmp = clone_uint32Array(HALF_3);
                 bigint_sub(tmp, base);
                 bigint_not(tmp);
                 bigint_add_small(tmp, 1);

--- a/lib/crypto/converter/words.js
+++ b/lib/crypto/converter/words.js
@@ -24,6 +24,14 @@ var clone_uint32Array = function(sourceArray) {
   return destination;
 };
 
+var ta_slice = function(array) {
+  if (array.slice !== undefined) {
+      return array.slice();
+  }
+
+  return clone_uint32Array(array);
+};
+
 var ta_reverse = function(array) {
   if (array.reverse !== undefined) {
     array.reverse();
@@ -163,7 +171,7 @@ var words_to_trits = function(words) {
         } else {
             /// bigint is between (unsigned) HALF_3 and (2**384 - 3**242/2).
             bigint_add_small(base, 1);
-            var tmp = clone_uint32Array(HALF_3);
+            var tmp = ta_slice(HALF_3);
             bigint_sub(tmp, base);
             base = tmp;
         }
@@ -217,7 +225,7 @@ var trits_to_words = function(trits) {
     if (trits.slice(0, 242).every(function(a) {
             a == -1
         })) {
-        base = clone_uint32Array(HALF_3);
+        base = ta_slice(HALF_3);
         bigint_not(base);
         bigint_add_small(base, 1);
     } else {
@@ -261,7 +269,7 @@ var trits_to_words = function(trits) {
                 // so we need to transform it to a two's complement representation
                 // of (base - HALF_3).
                 // as we don't have a wrapping (-), we need to use some bit magic
-                var tmp = clone_uint32Array(HALF_3);
+                var tmp = ta_slice(HALF_3);
                 bigint_sub(tmp, base);
                 bigint_not(tmp);
                 bigint_add_small(tmp, 1);


### PR DESCRIPTION
On android (react-native) lead to `undefined is not a function (evaluating 'HALF_3.slice(0)'`. 
Covers that with an alternative approach to copy an ArrayBuffer. 
Thanks to @th0br0 