### PR TITLE
Set content-type header for making requests

### DIFF
--- a/lib/utils/makeRequest.js
+++ b/lib/utils/makeRequest.js
@@ -30,7 +30,7 @@ makeRequest.prototype.open = function() {
 
     var request = new XMLHttpRequest();
     request.open('POST', this.provider, true);
-    //request.setRequestHeader('Content-Type','application/json');
+    request.setRequestHeader('Content-Type','application/json');
 
     if (this.token) {
         //request.withCredentials = true;


### PR DESCRIPTION
Using it for android (RN) throws `Payload is set and no content-type header specified`.