### PR TITLE
Added method to speed remainder transfer

### DIFF
--- a/lib/api/api.js
+++ b/lib/api/api.js
@@ -1226,8 +1226,13 @@ api.prototype.prepareTransfers = function(seed, transfers, options, callback) {
                 }
                 else if (remainder > 0) {
 
+                    var startIndex = 0;
+                    for(var k = 0; k < inputs.length; k++) {
+                        startIndex = Math.max(inputs.keyIndex, startIndex);
+                    }
+
                     // Generate a new Address by calling getNewAddress
-                    self.getNewAddress(seed, {'security': security}, function(error, address) {
+                    self.getNewAddress(seed, {'index': startIndex, 'security': security}, function(error, address) {
 
                         if (error) return callback(error)
 

--- a/lib/api/api.js
+++ b/lib/api/api.js
@@ -1228,8 +1228,10 @@ api.prototype.prepareTransfers = function(seed, transfers, options, callback) {
 
                     var startIndex = 0;
                     for(var k = 0; k < inputs.length; k++) {
-                        startIndex = Math.max(inputs.keyIndex, startIndex);
+                        startIndex = Math.max(inputs[k].keyIndex, startIndex);
                     }
+
+                    startIndex++;
 
                     // Generate a new Address by calling getNewAddress
                     self.getNewAddress(seed, {'index': startIndex, 'security': security}, function(error, address) {


### PR DESCRIPTION
Please review.

Instead of starting at index 0 to get the address for the remainder value, we can use the already present inputs and their respective address key index `keyIndex` to determine the largest (if not THE largest) already generated address index.

This should help transfers without a specified remainder address and a lot of used addresses because we won't need to regenerate all addresses starting from index 0.

I'm not sure about this change, waiting for comments.