### PR TITLE
Fixes, mostly related to RN and browser environments

### DIFF
--- a/lib/crypto/converter/words.js
+++ b/lib/crypto/converter/words.js
@@ -17,11 +17,10 @@ var HALF_3 = new Uint32Array([
     0x5e69ebef
 ]);
 
-var clone_uint32Array = function(sourceArray) {
-  var destination = new ArrayBuffer(sourceArray.byteLength);
-  new Uint32Array(destination).set(new Uint32Array(sourceArray));
+var clone_uint32Array = function(array) {
+  var source = new Uint32Array(array);
 
-  return destination;
+  return new Uint32Array(source);
 };
 
 var ta_slice = function(array) {

--- a/lib/utils/makeRequest.js
+++ b/lib/utils/makeRequest.js
@@ -1,6 +1,14 @@
-var XMLHttpRequest = require("xmlhttprequest").XMLHttpRequest;
 var errors = require("../errors/requestErrors");
 
+function xmlHttpRequest() {
+  if (typeof XMLHttpRequest !== 'undefined') {
+    return new XMLHttpRequest();
+  }
+
+  var module = 'xmlhttprequest';
+  var request = require(module).XMLHttpRequest;
+  return new request();
+}
 
 function makeRequest(provider, token) {
 
@@ -28,7 +36,7 @@ makeRequest.prototype.setProvider = function(provider) {
 **/
 makeRequest.prototype.open = function() {
 
-    var request = new XMLHttpRequest();
+    var request = xmlHttpRequest();
     request.open('POST', this.provider, true);
     request.setRequestHeader('Content-Type','application/json');
     request.setRequestHeader('X-IOTA-API-Version', '1');
@@ -86,7 +94,7 @@ makeRequest.prototype.sandboxSend = function(job, callback) {
 
     var newInterval = setInterval(function() {
 
-        var request = new XMLHttpRequest();
+        var request = xmlHttpRequest();
 
         request.onreadystatechange = function() {
 


### PR DESCRIPTION
`xmlhttprequest` is available in browser and RN environments by default but the default `require` forces the package manager to load the module which is dependent on node core modules (url, child_process). 

Previously we have been using a forked version but its kind of a pain with the updates. This would prevent bundling the `xmlhttprequest` package for environments that have this package available by default. 