### PR TITLE
Fix promoteTransaction; also allow to interrupt by function call

### DIFF
--- a/lib/api/api.js
+++ b/lib/api/api.js
@@ -624,7 +624,7 @@ api.prototype.sendTransfer = function(seed, depth, minWeightMagnitude, transfers
             return callback(error)
         }
 
-        self.sendTrytes(trytes, depth, minWeightMagnitude, callback);
+      self.sendTrytes(trytes, depth, minWeightMagnitude, options, callback);
     })
 }
 
@@ -652,9 +652,8 @@ api.prototype.promoteTransaction = function(tail, depth, minWeightMagnitude, tra
         return callback(errors.inconsistentSubtangle(tail));
       }
 
-      if (params.interrupt === true) {
-          return callback(null, tail);
-      }
+      if (params.interrupt === true || (typeof(params.interrupt) === 'function' && params.interrupt()))
+        return callback(null, tail);
 
       self.sendTransfer(transfer[0].address, depth, minWeightMagnitude, transfer, {reference: tail}, function(err, res) {
           if (err == null && params.delay > 0) {


### PR DESCRIPTION
Mainly passes the `options` object from `sendTransfer` to `sendTrytes` to fix promotion.

Also allows `promoteTransaction` to accept a function as `prams.interrupt` to
allow more advanced flow control. Compatibility with boolean interrupt is
preserved.