### PR TITLE
added check for undefined in isPromotable

### DIFF
--- a/lib/api/api.js
+++ b/lib/api/api.js
@@ -1955,7 +1955,7 @@ api.prototype.isPromotable = function(tail) {
             if (err) {
               rej(err)
             }
-            res(isConsistent.state);
+            res(isConsistent ? isConsistent.state : false);
         });
     });
     return promise.then(function(val) {

--- a/lib/api/api.js
+++ b/lib/api/api.js
@@ -643,15 +643,8 @@ api.prototype.sendTransfer = function(seed, depth, minWeightMagnitude, transfers
 */
 api.prototype.promoteTransaction = function(tail, depth, minWeightMagnitude, transfer, params, callback) {
     var self = this;
-    if (!inputValidator.isHash(tail)) {
-        return callback(errors.invalidTrytes());
-    }
 
     self.isPromotable(tail).then(function (isPromotable) {
-      if (!isPromotable) {
-        return callback(errors.inconsistentSubtangle(tail));
-      }
-
       if (params.interrupt === true || (typeof(params.interrupt) === 'function' && params.interrupt()))
         return callback(null, tail);
 
@@ -1942,24 +1935,21 @@ api.prototype.isReattachable = function(inputAddresses, callback) {
  */
 api.prototype.isPromotable = function(tail) {
     var self = this;
+    return new Promise(function(res, rej) {
 
-    // Check if is hash
-    if (!inputValidator.isHash(tail)) {
-        return false;
-    }
-
+        // Check if is hash
+        if (!inputValidator.isHash(tail)) {
+            rej(errors.invalidTrytes());
+        }
     var command = apiCommands.checkConsistency([tail]);
 
-    var promise = new Promise(function(res, rej) {
+    
         self.sendCommand(command, function(err, isConsistent) {
             if (err) {
-              rej(err)
+              rej(err);
             }
             else res(isConsistent.state);
         });
-    });
-    return promise.then(function(val) {
-        return val;
     });
 }
 

--- a/lib/api/api.js
+++ b/lib/api/api.js
@@ -1941,7 +1941,7 @@ api.prototype.isPromotable = function(tail) {
         if (!inputValidator.isHash(tail)) {
             rej(errors.invalidTrytes());
         }
-    var command = apiCommands.checkConsistency([tail]);
+        var command = apiCommands.checkConsistency([tail]);
 
     
         self.sendCommand(command, function(err, isConsistent) {

--- a/lib/api/api.js
+++ b/lib/api/api.js
@@ -1955,7 +1955,7 @@ api.prototype.isPromotable = function(tail) {
             if (err) {
               rej(err)
             }
-            res(isConsistent ? isConsistent.state : false);
+            else res(isConsistent.state);
         });
     });
     return promise.then(function(val) {


### PR DESCRIPTION
When calling api.promoTransaction with a bundle hash instead of a transaction hash the function isPromotable does not throw an error. It tries to read to ready isConsistent.state and throws "can not read state from undefined". This causes my app to crash and probably others as well.

I have now made sure that it simply returns false, causing the promotion to stop and return control to the app. It might be better to change the function that actually checks consistency, or add a check to differentiate between bundleHash and transactionHash (if that is possible?). But for now it fixes this issue.

Any feedback is welcome, as this is my first PR here on github. :)