### PR TITLE
prevent type error in isPromotable

### DIFF
--- a/lib/api/api.js
+++ b/lib/api/api.js
@@ -1955,7 +1955,7 @@ api.prototype.isPromotable = function(tail) {
             if (err) {
               rej(err)
             }
-            res(isConsistent.state);
+            res(isConsistent);
         });
     });
     return promise.then(function(val) {

--- a/lib/utils/makeRequest.js
+++ b/lib/utils/makeRequest.js
@@ -272,7 +272,8 @@ makeRequest.prototype.prepareResult = function(result, requestCommand, callback)
         'findTransactions'      :   'hashes',
         'getTrytes'             :   'trytes',
         'getInclusionStates'    :   'states',
-        'attachToTangle'        :   'trytes'
+        'attachToTangle'        :   'trytes',
+        'checkConsistency'      :   'state'
     }
 
     var error;


### PR DESCRIPTION
Enables parsing of `checkConsistency()` response in `utils.prepareResult()` to prevent type errors.