### PR TITLE
add wereAddressesSpentFrom() to api

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: node_js
 node_js:
     - "node"
     - "4.1"
-    - "4.0"
 before_script:
     - npm install
     - npm install -g gulp

--- a/lib/api/api.js
+++ b/lib/api/api.js
@@ -1990,7 +1990,7 @@ api.prototype.wereAddressesSpentFrom = function (addresses, callback) {
   }
 
   return self.sendCommand(apiCommands.wereAddressesSpentFrom(addresses.map(function (address) {
-    Utils.noChecksum(address)
+    return Utils.noChecksum(address)
   })), callback)
 }
 

--- a/lib/api/api.js
+++ b/lib/api/api.js
@@ -850,37 +850,43 @@ api.prototype.getNewAddress = function(seed, options, callback) {
     }
     //  Case 2: no total provided
     //
-    //  Continue calling findTransactions to see if address was already created
+    //  Continue calling wasAddressSpenFrom & findTransactions to see if address was already created
     //  if null, return list of addresses
     //
     else {
 
         async.doWhilst(function(callback) {
-            // Iteratee function
+          // Iteratee function
+          var newAddress = self._newAddress(seed, index, security, checksum)
 
-            var newAddress = self._newAddress(seed, index, security, checksum);
+          if (options.returnAll) {
+            allAddresses.push(newAddress)
+          }
 
-            self.findTransactions({'addresses': Array(newAddress)}, function(error, transactions) {
+          // Increase the index
+          index += 1
 
-                if (error) {
-                    return callback(error);
-                }
-                callback(null, newAddress, transactions)
-            })
-
-        }, function(address, transactions) {
-            // Test function with validity check
-
-            if (options.returnAll) {
-                allAddresses.push(address)
+          self.wereAddressesSpentFrom(newAddress, function (err, res) {
+            if (err) {
+              return callback(err)
             }
 
-            // Increase the index
-            index += 1;
-
             // Validity check
-            return transactions.length > 0;
+            if (res[0]) {
+              callback(null, newAddress, true)
+            } else { // Check for txs if address isn't spent
+              self.findTransactions({'addresses': [newAddress]}, function (err, transactions) {
+                if (err) {
+                  return callback(err)
+                }
 
+                callback(err, newAddress, transactions.length > 0)
+              })
+            }
+          })
+
+        }, function (address, isUsed) {
+          return isUsed
         }, function(err, address) {
             // Final callback
 
@@ -1963,4 +1969,29 @@ api.prototype.isPromotable = function(tail) {
     });
 }
 
-module.exports = api;
+/**
+ *  Check if an address or list of addresses have been sepnt from
+ *  @method wereAddressesSpentFrom
+ *  @param {string|array} addresses Address or addresses
+ *  @param {function} callback
+ *  @return
+ */
+api.prototype.wereAddressesSpentFrom = function (addresses, callback) {
+  var self = this
+
+  if (!Array.isArray(addresses)) {
+    addresses = [addresses]
+  }
+
+  if (addresses.some(function (address) {
+    return !inputValidator.isAddress(address)
+  })) {
+    return callback(errors.invalidAddress())
+  }
+
+  return self.sendCommand(apiCommands.wereAddressesSpentFrom(addresses.map(function (address) {
+    Utils.noChecksum(address)
+  })), callback)
+}
+
+module.exports = api

--- a/lib/api/apiCommands.js
+++ b/lib/api/apiCommands.js
@@ -224,9 +224,9 @@ var storeTransactions = function(trytes) {
 }
 
 /**
-* @method  returns whether the given tail is consistent
-* @param tail bundle tail hash
-* @returns   {object} command
+*   @method returns whether the given tail is consistent
+*   @param {string} tail bundle tail hash
+*   @returns {object} command
 */
 var checkConsistency = function(hashes) {
 
@@ -238,6 +238,20 @@ var checkConsistency = function(hashes) {
     return command;
 }
 
+/**
+*   @method wereAddressesSpentFrom
+*   @param {array} addresses Addresses to check
+*   @returns {object} command
+*/
+var wereAddressesSpentFrom = function (addresses) {
+
+    var command = {
+        'command': 'wereAddressesSpentFrom',
+        'addresses': addresses
+    }
+
+    return command
+}
 
 module.exports = {
     attachToTangle              : attachToTangle,
@@ -254,5 +268,6 @@ module.exports = {
     interruptAttachingToTangle  : interruptAttachingToTangle,
     checkConsistency            : checkConsistency,
     broadcastTransactions       : broadcastTransactions,
-    storeTransactions           : storeTransactions
+    storeTransactions           : storeTransactions,
+    wereAddressesSpentFrom      : wereAddressesSpentFrom
 }

--- a/lib/errors/inputErrors.js
+++ b/lib/errors/inputErrors.js
@@ -1,6 +1,9 @@
 
 module.exports = {
 
+    invalidAddress: function () {
+        return new Error("Invalid address provided");
+    },
     invalidTrytes: function() {
         return new Error("Invalid Trytes provided");
     },

--- a/lib/utils/makeRequest.js
+++ b/lib/utils/makeRequest.js
@@ -272,7 +272,8 @@ makeRequest.prototype.prepareResult = function(result, requestCommand, callback)
         'findTransactions'      :   'hashes',
         'getTrytes'             :   'trytes',
         'getInclusionStates'    :   'states',
-        'attachToTangle'        :   'trytes'
+        'attachToTangle'        :   'trytes',
+        'wereAddressesSpentFrom':   'states'
     }
 
     var error;

--- a/test/api/api.getNewAddress.js
+++ b/test/api/api.getNewAddress.js
@@ -1,0 +1,59 @@
+var { assert } = require('chai')
+var API = require('../../lib/api/api')
+
+describe('api.getNewAddress', () => {
+  var seed = 'SEED'
+  var addresses = [
+    'FJHSSHBZTAKQNDTIKJYCZBOZDGSZANCZSWCNWUOCZXFADNOQSYAHEJPXRLOVPNOQFQXXGEGVDGICLMOXX',
+    '9DZXPFSVCSSWXXQPFMWLGFKPBAFTHYMKMZCPFHBVHXPFNJEIJIEEPKXAUBKBNNLIKWHJIYQDFWQVELOCB',
+    'OTSZGTNPKFSGJLUPUNGGXFBYF9GVUEHOADZZTDEOJPWNEIVBLHOMUWPILAHTQHHVSBKTDVQIAEQOZXGFB'
+  ]
+  var expected = '9DZXPFSVCSSWXXQPFMWLGFKPBAFTHYMKMZCPFHBVHXPFNJEIJIEEPKXAUBKBNNLIKWHJIYQDFWQVELOCB'
+  var i = 0
+
+  API.prototype.wereAddressesSpentFrom = function (address, cb) {
+    return cb(null, tests[i].wereAddressesSpentFrom[address])
+  }
+
+  API.prototype.findTransactions = function (query, cb) {
+    console.log(query)
+    return cb(null, tests[i].findTransactions[query.addresses[0]])
+  }
+
+  const api = new API()
+
+  var tests = [
+    {
+      title: 'Should skip spent addresses',
+      wereAddressesSpentFrom: {
+        [addresses[0]]: [true],
+        [addresses[1]]: [false]
+      },
+      findTransactions: {
+        [addresses[0]]: [],
+        [addresses[1]]: []
+      },
+      expected: expected
+    }, {
+      title: 'Should skip addresses with transactions',
+      wereAddressesSpentFrom: {
+        [addresses[0]]: [false],
+        [addresses[1]]: [false]
+      },
+      findTransactions: {
+        [addresses[0]]: ['A'],
+        [addresses[1]]: []
+      },
+      expected: expected
+    }
+  ]
+
+  tests.forEach(function (t) {
+    it(t.title, function () {
+      api.getNewAddress(seed, function (err, address) {
+        assert.deepEqual(address, t.expected)
+        i++
+      })
+    })
+  })
+})

--- a/test/api/api.getNewAddress.js
+++ b/test/api/api.getNewAddress.js
@@ -1,4 +1,5 @@
-var { assert } = require('chai')
+var chai = require('chai');
+var assert = chai.assert;
 var API = require('../../lib/api/api')
 
 describe('api.getNewAddress', function () {

--- a/test/api/api.getNewAddress.js
+++ b/test/api/api.getNewAddress.js
@@ -1,7 +1,9 @@
 var { assert } = require('chai')
 var API = require('../../lib/api/api')
 
-describe('api.getNewAddress', () => {
+describe('api.getNewAddress', function () {
+  this.timeout(10000)
+
   var seed = 'SEED'
   var addresses = [
     'FJHSSHBZTAKQNDTIKJYCZBOZDGSZANCZSWCNWUOCZXFADNOQSYAHEJPXRLOVPNOQFQXXGEGVDGICLMOXX',


### PR DESCRIPTION
- Added `wereAddressesSpentFrom()` command, which checks if addresses were used in current or previous epoch.
- Refactored `getNewAddress()` to utilize the new method.