### PR TITLE
Fix dynamic require for usage with webpack

### DIFF
--- a/lib/utils/makeRequest.js
+++ b/lib/utils/makeRequest.js
@@ -5,9 +5,7 @@ function xmlHttpRequest() {
   if (typeof XMLHttpRequest !== 'undefined') {
     return new XMLHttpRequest();
   }
-  pretendingNotToRequire = require;
-  var module = 'xmlhttprequest';
-  var request = pretendingNotToRequire(module).XMLHttpRequest;
+  var request = require('xmlhttprequest').XMLHttpRequest;
   return new request();
 }
 


### PR DESCRIPTION
This fix #158
I didn't understand what was the purpose to use a variable inside the require. Webpack is very common in web development, use a variable in a require is not allowed by Webpack, so this issue make iota.lib.js not usable in a web application.