### PR TITLE
remove checksum from inputs in addRemainer

### DIFF
--- a/lib/api/api.js
+++ b/lib/api/api.js
@@ -1273,9 +1273,10 @@ api.prototype.prepareTransfers = function(seed, transfers, options, callback) {
             var thisBalance = inputs[i].balance;
             var toSubtract = 0 - thisBalance;
             var timestamp = Math.floor(Date.now() / 1000);
+            var address = Utils.noChecksum(inputs[i].address);
 
             // Add input as bundle entry
-            bundle.addEntry(inputs[i].security, inputs[i].address, toSubtract, tag, timestamp);
+            bundle.addEntry(inputs[i].security, address, toSubtract, tag, timestamp);
 
             // If there is a remainder value
             // Add extra output to send remaining funds to


### PR DESCRIPTION
This change allows more flexibility when providing inputs yourself since `bundle.addEntry` needs address without checksum and you only get a cryptic `Error: Illegal length provided` from `Kerl.prototype.absorb`