### PR TITLE
Fix warning about require with an expression instead of a string

### DIFF
--- a/lib/utils/makeRequest.js
+++ b/lib/utils/makeRequest.js
@@ -6,8 +6,7 @@ function xmlHttpRequest() {
     return new XMLHttpRequest();
   }
   pretendingNotToRequire = require;
-  var module = 'xmlhttprequest';
-  var request = pretendingNotToRequire(module).XMLHttpRequest;
+  var request = pretendingNotToRequire('xmlhttprequest').XMLHttpRequest;
   return new request();
 }
 


### PR DESCRIPTION
`require` call for 'xmlhttprequest' in `makeRequest.js` is called with a variable instead of a string, causing warnings in build tools.

```
warning  in ./~/iota.lib.js/lib/utils/makeRequest.js
10:16-46 Critical dependency: the request of a dependency is an expression
```
Simply removing the variable and passing the string directly fixes that. There is no point in caching that string in a variable anyway.