### PR TITLE
Failing Travis CI builds: dependency gulp-nsp's update broke support for Node versions <5.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "del": "^3.0.0",
     "gulp": "^3.9.1",
     "gulp-jshint": "^2.0.2",
-    "gulp-nsp": ">=2.4.2",
+    "gulp-nsp": ">=2.4.2 <3.0.0",
     "gulp-rename": ">=1.2.2",
     "gulp-replace": "^0.6.1",
     "gulp-uglify": "^3.0.0",


### PR DESCRIPTION
gulp-nsp is using the spread operator since about a month ago and thus killed support for Node < 5.
Which is causing all travis builds to fail on the second job due to the usage of Node v.4.1.2 for that.

https://github.com/nodesecurity/gulp-nsp/commit/92de6321816a4a50e45282b1ec03a64674634047#diff-168726dbe96b3ce427e7fedce31bb0bcR14

A better way to handle this would be either to drop gulp all together or stop trying to run tests / support for Node v4.1.2 (and move the minimum version to Node 5+)