### PR TITLE
Support for remote authentication

### DIFF
--- a/lib/iota.js
+++ b/lib/iota.js
@@ -32,7 +32,7 @@ IOTA.prototype.setSettings = function(settings) {
         this.provider = this.sandbox + '/commands';
     }
 
-    this._makeRequest = new makeRequest({provider: this.provider, token: this.token, username: this.username, password: this.password});
+    this._makeRequest = new makeRequest(this.provider, this.token || this.username, this.password);
     this.api = new api(this._makeRequest, this.sandbox);
     // this.mam
     // this.flash

--- a/lib/iota.js
+++ b/lib/iota.js
@@ -18,20 +18,23 @@ function IOTA(settings) {
 IOTA.prototype.setSettings = function(settings) {
     // IF NO SETTINGS, SET DEFAULT TO localhost:14265
     settings = settings || {};
+console.log(JSON.stringify(settings));
     this.version = require('../package.json').version;
     this.host = settings.host || "http://localhost";
     this.port = settings.port || 14265;
     this.provider = settings.provider || this.host.replace(/\/$/, '') + ":" + this.port;
     this.sandbox = settings.sandbox || false;
     this.token = settings.token || false;
-
+    this.username = settings.username || false;
+    this.password = settings.password || false;
+console.log(`provider is ${this.provider}`);
     if (this.sandbox) {
         // remove backslash character
         this.sandbox = this.provider.replace(/\/$/, '');
         this.provider = this.sandbox + '/commands';
     }
 
-    this._makeRequest = new makeRequest(this.provider, this.token);
+    this._makeRequest = new makeRequest({provider: this.provider, token: this.token, username: this.username, password: this.password});
     this.api = new api(this._makeRequest, this.sandbox);
     // this.mam
     // this.flash

--- a/lib/iota.js
+++ b/lib/iota.js
@@ -18,7 +18,6 @@ function IOTA(settings) {
 IOTA.prototype.setSettings = function(settings) {
     // IF NO SETTINGS, SET DEFAULT TO localhost:14265
     settings = settings || {};
-console.log(JSON.stringify(settings));
     this.version = require('../package.json').version;
     this.host = settings.host || "http://localhost";
     this.port = settings.port || 14265;
@@ -27,7 +26,6 @@ console.log(JSON.stringify(settings));
     this.token = settings.token || false;
     this.username = settings.username || false;
     this.password = settings.password || false;
-console.log(`provider is ${this.provider}`);
     if (this.sandbox) {
         // remove backslash character
         this.sandbox = this.provider.replace(/\/$/, '');

--- a/lib/utils/makeRequest.js
+++ b/lib/utils/makeRequest.js
@@ -11,12 +11,11 @@ function xmlHttpRequest() {
   return new request();
 }
 
-function makeRequest(data) {
+function makeRequest(provider, tokenOrUsername, password) {
 
-    this.provider = data.provider || "http://localhost:14265";
-    this.token = data.token;
-    this.username = data.username || false;
-    this.password = data.password || false;
+    this.provider = provider || "http://localhost:14265";
+    this.tokenOrUsername = tokenOrUsername;
+    this.password = password || false;
     this.timeout = -1;
 
 }
@@ -53,17 +52,17 @@ makeRequest.prototype.open = function() {
 
     var request = xmlHttpRequest();
 
-    if(this.username && this.password) {
-        request.open('POST', this.provider, true, this.username, this.password);
+    if(this.password) {
+        request.open('POST', this.provider, true, this.tokenOrUsername, this.password);
     } else {
         request.open('POST', this.provider, true);
     }
     request.setRequestHeader('Content-Type','application/json');
     request.setRequestHeader('X-IOTA-API-Version', '1');
 
-    if (this.token) {
+    if (!this.password && this.tokenOrUsername) {
         //request.withCredentials = true;
-        request.setRequestHeader('Authorization', 'token ' + this.token);
+        request.setRequestHeader('Authorization', 'token ' + this.tokenOrUsername);
     }
 
     if (this.timeout > 0) {

--- a/lib/utils/makeRequest.js
+++ b/lib/utils/makeRequest.js
@@ -18,7 +18,7 @@ function makeRequest(data) {
     this.username = data.username || false;
     this.password = data.password || false;
     this.timeout = -1;
-console.log(`makeRequest with username/password ${this.username} ${this.password}`);
+
 }
 
 /**

--- a/lib/utils/makeRequest.js
+++ b/lib/utils/makeRequest.js
@@ -11,11 +11,14 @@ function xmlHttpRequest() {
   return new request();
 }
 
-function makeRequest(provider, token) {
+function makeRequest(data) {
 
-    this.provider = provider || "http://localhost:14265";
-    this.token = token;
+    this.provider = data.provider || "http://localhost:14265";
+    this.token = data.token;
+    this.username = data.username || false;
+    this.password = data.password || false;
     this.timeout = -1;
+console.log(`makeRequest with username/password ${this.username} ${this.password}`);
 }
 
 /**
@@ -49,7 +52,12 @@ makeRequest.prototype.setProvider = function(provider) {
 makeRequest.prototype.open = function() {
 
     var request = xmlHttpRequest();
-    request.open('POST', this.provider, true);
+
+    if(this.username && this.password) {
+        request.open('POST', this.provider, true, this.username, this.password);
+    } else {
+        request.open('POST', this.provider, true);
+    }
     request.setRequestHeader('Content-Type','application/json');
     request.setRequestHeader('X-IOTA-API-Version', '1');
 


### PR DESCRIPTION
# Description

Cannot seem to query a node using the `--remote-auth` flag in IRI. This PR allows an IOTA constructor to consume username and password variables, and uses them when making http requests.

Fixes #34 

## Type of change

- [x] Enhancement (non-breaking change which adds functionality)
