### PR TITLE
test getAccountData when called with start index > 0

### DIFF
--- a/packages/core/test/integration/getAccountData.test.ts
+++ b/packages/core/test/integration/getAccountData.test.ts
@@ -72,6 +72,22 @@ test('getAccountData() rejects with correct errors for invalid inputs', t => {
     )
 })
 
+test('getAccountData() with start > 0 resolves to correct account data.', async t => {
+    const expected = {
+        ...accountData,
+        addresses: accountData.addresses.slice(1, 3),
+        balance: balancesResponse.balances
+          .slice(1, 3)
+          .reduce((acc, balance) => acc + balance, 0)
+    }
+
+    t.deepEqual(
+        await getAccountData(seed, { start: 1 }),
+        expected,
+        'getAccountData() with start > 0 should resolve to correct account data'
+    )
+})
+
 test.cb('getAccountData() invokes callback', t => {
     getAccountData(seed, { start: 0 }, t.end)
 })

--- a/packages/core/test/integration/nocks/findTransactions.ts
+++ b/packages/core/test/integration/nocks/findTransactions.ts
@@ -126,3 +126,15 @@ nock('http://localhost:14265', headers)
         ]
     })
     .reply(200, findTransactionsResponse)
+
+
+nock('http://localhost:14265', headers)
+    .persist()
+    .post('/', {
+        command: IRICommand.FIND_TRANSACTIONS,
+        addresses: [
+            '9DZXPFSVCSSWXXQPFMWLGFKPBAFTHYMKMZCPFHBVHXPFNJEIJIEEPKXAUBKBNNLIKWHJIYQDFWQVELOCB',
+            'OTSZGTNPKFSGJLUPUNGGXFBYF9GVUEHOADZZTDEOJPWNEIVBLHOMUWPILAHTQHHVSBKTDVQIAEQOZXGFB'
+        ]
+    })
+    .reply(200, findTransactionsResponse)

--- a/packages/core/test/integration/nocks/getBalances.ts
+++ b/packages/core/test/integration/nocks/getBalances.ts
@@ -22,3 +22,17 @@ export const getBalancesNock = nock('http://localhost:14265', headers)
     .persist()
     .post('/', getBalancesCommand)
     .reply(200, balancesResponse)
+
+nock('http://localhost:14265', headers)
+    .persist()
+    .post('/', {
+        ...getBalancesCommand,
+        addresses: [
+            '9DZXPFSVCSSWXXQPFMWLGFKPBAFTHYMKMZCPFHBVHXPFNJEIJIEEPKXAUBKBNNLIKWHJIYQDFWQVELOCB',
+            'OTSZGTNPKFSGJLUPUNGGXFBYF9GVUEHOADZZTDEOJPWNEIVBLHOMUWPILAHTQHHVSBKTDVQIAEQOZXGFB'
+        ]
+    })
+    .reply(200, {
+        ...balancesResponse,
+        balances: ['1', '9']
+    })

--- a/packages/core/test/integration/nocks/wereAddressesSpentFrom.ts
+++ b/packages/core/test/integration/nocks/wereAddressesSpentFrom.ts
@@ -54,3 +54,16 @@ nock('http://localhost:14265', headers)
     .reply(200, {
         states: [false]
     })
+
+nock('http://localhost:14265', headers)
+    .persist()
+    .post('/', {
+        command: IRICommand.WERE_ADDRESSES_SPENT_FROM,
+        addresses: [
+            '9DZXPFSVCSSWXXQPFMWLGFKPBAFTHYMKMZCPFHBVHXPFNJEIJIEEPKXAUBKBNNLIKWHJIYQDFWQVELOCB',
+            'OTSZGTNPKFSGJLUPUNGGXFBYF9GVUEHOADZZTDEOJPWNEIVBLHOMUWPILAHTQHHVSBKTDVQIAEQOZXGFB'
+        ]
+    })
+    .reply(200, {
+        states: [false, false]
+    })


### PR DESCRIPTION
# Description

Adds test for `getAccountData` when called with `options.start > 0`.

Ensures `start + index` works:
https://github.com/iotaledger/iota.lib.js/pull/232/files#diff-7fa618e02ddc1cb618bed5a4bc853f3cR161

Related to #183 & #184  (change of this PR applies to `next` branch)

## Type of change

- [x] Test addition

# How Has This Been Tested?
Added test brakes when replacing `start + i` w/ `0 + i` in line bellow:
https://github.com/iotaledger/iota.lib.js/pull/232/files#diff-7fa618e02ddc1cb618bed5a4bc853f3cR161

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
