### PR TITLE
fix export of composeAPI and have it accept provider factory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ coverage
 *.log
 *.cache
 package-lock.json
+/packages/*/yarn.lock

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ yarn add @iota/core
 ### Connecting to network
 
 ```js
-import composeApi from '@iota/core'
+import { composeApi } from '@iota/core'
 
 const iota = composeApi({
     provider: 'http://localhost:14265'

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -83,11 +83,7 @@ export { createBroadcastBundle } from './createBroadcastBundle'
 
 export { createFindTransactionObjects } from './createFindTransactionObjects'
 
-export {
-    createGetAccountData,
-    GetAccountDataOptions,
-    AccountData
-} from './createGetAccountData'
+export { createGetAccountData, GetAccountDataOptions, AccountData } from './createGetAccountData'
 
 export { createGetBundle } from './createGetBundle'
 
@@ -97,10 +93,7 @@ export { createGetBundle } from './createGetBundle'
 //
 // export { createGetBundlesFromAddresses } from './createGetBundlesFromAddresses'
 
-export {
-    createGetInputs,
-    GetInputsOptions
-} from './createGetInputs'
+export { createGetInputs, GetInputsOptions } from './createGetInputs'
 
 export { createGetLatestInclusion } from './createGetLatestInclusion'
 
@@ -128,10 +121,7 @@ export { isAboveMaxDepth, createIsPromotable } from './createIsPromotable'
 
 export { createIsReattachable } from './createIsReattachable'
 
-export {
-    createPromoteTransaction,
-    PromoteTransactionOptions
-} from './createPromoteTransaction'
+export { createPromoteTransaction, PromoteTransactionOptions } from './createPromoteTransaction'
 
 export { createReplayBundle } from './createReplayBundle'
 
@@ -150,4 +140,4 @@ import * as errors from './errors'
 export { errors }
 
 // export api factory with default provider
-export { API, composeAPI as default, Settings } from './composeAPI'
+export { API, composeAPI, Settings } from './composeAPI'

--- a/packages/core/test/integration/composeAPI.test.ts
+++ b/packages/core/test/integration/composeAPI.test.ts
@@ -6,11 +6,11 @@ import { getNodeInfoResponse } from './nocks/getNodeInfo'
 test('composeAPI() composes API with provider factory', async t => {
     const api: any = (composeAPI(createHttpClient) as (s?: Partial<object>) => API)()
 
-    t.deepEqual(await api.getNodeInfo(), getNodeInfoResponse, 'getNodeInfo() should resolve to correct node info')
+    t.deepEqual(await api.getNodeInfo(), getNodeInfoResponse, 'composeAPI() should compose API with provider factory')
 })
 
 test('composeAPI() composes API with default provider', async t => {
     const api: any = composeAPI()
 
-    t.deepEqual(await api.getNodeInfo(), getNodeInfoResponse, 'getNodeInfo() should resolve to correct node info')
+    t.deepEqual(await api.getNodeInfo(), getNodeInfoResponse, 'getNodeInfo() should compose API with default provider')
 })

--- a/packages/core/test/integration/composeAPI.test.ts
+++ b/packages/core/test/integration/composeAPI.test.ts
@@ -1,0 +1,16 @@
+import test from 'ava'
+import { createHttpClient } from '@iota/http-client'
+import { composeAPI, API } from '../../src'
+import { getNodeInfoResponse } from './nocks/getNodeInfo'
+
+test('composeAPI() composes API with provider factory', async t => {
+    const api: any = (composeAPI(createHttpClient) as (s?: Partial<object>) => API)()
+
+    t.deepEqual(await api.getNodeInfo(), getNodeInfoResponse, 'getNodeInfo() should resolve to correct node info')
+})
+
+test('composeAPI() composes API with default provider', async t => {
+    const api: any = composeAPI()
+
+    t.deepEqual(await api.getNodeInfo(), getNodeInfoResponse, 'getNodeInfo() should resolve to correct node info')
+})

--- a/packages/types.ts
+++ b/packages/types.ts
@@ -18,12 +18,7 @@ export interface Address extends Balance {
     readonly security: number
 }
 
-export const makeAddress = (
-    address: Hash,
-    balance: number,
-    keyIndex: number,
-    security: number
-): Address => ({
+export const makeAddress = (address: Hash, balance: number, keyIndex: number, security: number): Address => ({
     address,
     keyIndex,
     security,
@@ -288,6 +283,8 @@ export interface Provider {
     readonly setSettings: <S>(settings?: Readonly<Partial<S>>) => void
 }
 
+export type CreateProvider = (settings?: Partial<object>) => Provider
+
 /** Attach to tangle */
 export type AttachToTangle = (
     trunkTransaction: Hash,
@@ -298,12 +295,7 @@ export type AttachToTangle = (
 ) => Promise<ReadonlyArray<Trytes>>
 
 /* Util methods */
-export const asArray = <T>(
-    x: T | ReadonlyArray<T>
-): ReadonlyArray<T> => (
-        Array.isArray(x) ? x : [x]
-    )
+export const asArray = <T>(x: T | ReadonlyArray<T>): ReadonlyArray<T> => (Array.isArray(x) ? x : [x])
 
-export const getOptionsWithDefaults = <T>(defaults: Readonly<T>) =>
-    (options: Readonly<Partial<T>>): Readonly<T> =>
-        Object.assign({}, defaults, options) // tslint:disable-line prefer-object-spread
+export const getOptionsWithDefaults = <T>(defaults: Readonly<T>) => (options: Readonly<Partial<T>>): Readonly<T> =>
+    Object.assign({}, defaults, options) // tslint:disable-line prefer-object-spread


### PR DESCRIPTION
# Description

- Fixes `composeAPI` export in core
- `composeAPI` now accepts `settings` object or provider factory such as [`createHttpClient`](https://github.com/iotaledger/iota.lib.js/tree/next/packages/http-client#module_http-client..createHttpClient)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (non-breaking change which adds functionality)

# How Has This Been Tested?
https://github.com/chrisdukakis/iota.lib.js/blob/2e5ca8d57922bb0ca45cc3dc97878213262b7a08/packages/core/test/integration/composeAPI.test.ts

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
