### PR TITLE
missing } on options object on prepareTransfers()

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,7 +356,7 @@ iota.api.prepareTransfers(seed,
             keyIndex: 7,
             security: 2
         }
-    ], function(e, s) {
+    ]}, function(e, s) {
 
 
         console.log(e,s);


### PR DESCRIPTION
Just added a } to close options object on prepareTransfers example
