### PR TITLE
checkConsistency: fix `tails` field & optionally reject with reason if state is false [next branch]

### DIFF
--- a/api_reference.md
+++ b/api_reference.md
@@ -288,7 +288,7 @@ Converts an integer value to trits
 
     * [.createCheckConsistency(provider)](#module_core.createCheckConsistency)
 
-    * [.checkConsistency(transactions, [callback])](#module_core.checkConsistency)
+    * [.checkConsistency(transactions, [options], [callback])](#module_core.checkConsistency)
 
     * [.createFindTransactionObjects(provider)](#module_core.createFindTransactionObjects)
 
@@ -591,15 +591,18 @@ broadcastTransactions(trytes)
 **Returns**: <code>function</code> - [`checkConsistency`](#module_core.checkConsistency)  
 <a name="module_core.checkConsistency"></a>
 
-### *core*.checkConsistency(transactions, [callback])
+### *core*.checkConsistency(transactions, [options], [callback])
 **Fulfil**: <code>boolean</code> Consistency state of given transaction or co-consistency of given transactions.  
 **Reject**: <code>Error</code>
 - `IVNALID_HASH_ARRAY`: Invalid array of hashes
-- Fetch error  
+- Fetch error
+- Reason for returning `false`, if called with `options.rejectWithReason`  
 
 | Param | Type | Description |
 | --- | --- | --- |
 | transactions | <code>Hash</code> \| <code>Array.&lt;Hash&gt;</code> | Tail transaction hash (hash of transaction with `currentIndex=0`), or array of tail transaction hashes. |
+| [options] | <code>object</code> | Options |
+| [options.rejectWithReason] | <code>boolean</code> | Enables rejection if state is `false`, with reason as error message |
 | [callback] | <code>Callback</code> | Optional callback. |
 
 Checks if a transaction is _consistent_ or a set of transactions are _co-consistent_, by calling

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -47,7 +47,7 @@ yarn add @iota/core
 
     * [.createCheckConsistency(provider)](#module_core.createCheckConsistency)
 
-    * [.checkConsistency(transactions, [callback])](#module_core.checkConsistency)
+    * [.checkConsistency(transactions, [options], [callback])](#module_core.checkConsistency)
 
     * [.createFindTransactionObjects(provider)](#module_core.createFindTransactionObjects)
 
@@ -350,15 +350,18 @@ broadcastTransactions(trytes)
 **Returns**: <code>function</code> - [`checkConsistency`](#module_core.checkConsistency)  
 <a name="module_core.checkConsistency"></a>
 
-### *core*.checkConsistency(transactions, [callback])
+### *core*.checkConsistency(transactions, [options], [callback])
 **Fulfil**: <code>boolean</code> Consistency state of given transaction or co-consistency of given transactions.  
 **Reject**: <code>Error</code>
 - `IVNALID_HASH_ARRAY`: Invalid array of hashes
-- Fetch error  
+- Fetch error
+- Reason for returning `false`, if called with `options.rejectWithReason`  
 
 | Param | Type | Description |
 | --- | --- | --- |
 | transactions | <code>Hash</code> \| <code>Array.&lt;Hash&gt;</code> | Tail transaction hash (hash of transaction with `currentIndex=0`), or array of tail transaction hashes. |
+| [options] | <code>object</code> | Options |
+| [options.rejectWithReason] | <code>boolean</code> | Enables rejection if state is `false`, with reason as error message |
 | [callback] | <code>Callback</code> | Optional callback. |
 
 Checks if a transaction is _consistent_ or a set of transactions are _co-consistent_, by calling

--- a/packages/core/src/composeAPI.ts
+++ b/packages/core/src/composeAPI.ts
@@ -37,6 +37,7 @@ import {
     // Types
     AccountData,
     Balances,
+    CheckConsistencyOptions,
     FindTransactionsQuery,
     GetAccountDataOptions,
     GetInputsOptions,

--- a/packages/core/src/createCheckConsistency.ts
+++ b/packages/core/src/createCheckConsistency.ts
@@ -113,7 +113,7 @@ export const createCheckConsistency = ({ send }: Provider) =>
             )
             .then(({ state, info }) => {
                 if (rejectWithReason && !state) {
-                    throw new Error(info)
+                    throw new Error(`Transaction is inconsistent. Reason: ${info}`)
                 }
 
                 return state

--- a/packages/core/src/createCheckConsistency.ts
+++ b/packages/core/src/createCheckConsistency.ts
@@ -10,6 +10,7 @@ import {
     IRICommand,
     Provider,
 } from '../../types'
+import { inconsistentTransaction } from './errors'
 
 export interface CheckConsistencyOptions {
     rejectWithReason?: boolean
@@ -113,7 +114,7 @@ export const createCheckConsistency = ({ send }: Provider) =>
             )
             .then(({ state, info }) => {
                 if (rejectWithReason && !state) {
-                    throw new Error(`Transaction is inconsistent. Reason: ${info}`)
+                    throw new Error(inconsistentTransaction(info))
                 }
 
                 return state

--- a/packages/core/src/createCheckConsistency.ts
+++ b/packages/core/src/createCheckConsistency.ts
@@ -93,7 +93,7 @@ export const createCheckConsistency = ({ send }: Provider) =>
             .then(() =>
                 send<CheckConsistencyCommand, CheckConsistencyResponse>({
                     command: IRICommand.CHECK_CONSISTENCY,
-                    transactions: asArray(transactions),
+                    tails: asArray(transactions),
                 })
             )
             .then(({ state }) => state)

--- a/packages/core/src/createPromoteTransaction.ts
+++ b/packages/core/src/createPromoteTransaction.ts
@@ -92,7 +92,7 @@ export const createPromoteTransaction = (provider: Provider, attachFn?: AttachTo
         }
 
         return Bluebird.resolve(validate(hashValidator(tailTransaction), transferArrayValidator(spamTransfers)))
-            .then(() => checkConsistency(tailTransaction))
+            .then(() => checkConsistency(tailTransaction, { rejectWithReason: true }))
             .then(consistent => {
                 if (!consistent) {
                     throw new Error(errors.INCONSISTENT_SUBTANGLE)

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -42,3 +42,4 @@ export const INVALID_TRYTE_ENCODED_JSON = 'Invalid tryte encoded JSON message'
 export const NOT_INT = 'One of the inputs is not integer'
 export const SENDING_BACK_TO_INPUTS = 'One of the transaction inputs is used as output.'
 export const invalidChecksum = (address: string) => `Invalid Checksum: ${address}`
+export const inconsistentTransaction = (reason: string) => `Transaction is inconsistent. Reason: ${reason}`

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -43,7 +43,7 @@ export { createAttachToTangle } from './createAttachToTangle'
 
 export { createBroadcastTransactions } from './createBroadcastTransactions'
 
-export { createCheckConsistency } from './createCheckConsistency'
+export { createCheckConsistency, CheckConsistencyOptions } from './createCheckConsistency'
 
 export { createFindTransactions } from './createFindTransactions'
 

--- a/packages/core/test/integration/checkConsistency.test.ts
+++ b/packages/core/test/integration/checkConsistency.test.ts
@@ -8,7 +8,7 @@ const checkConsistency = createCheckConsistency(createHttpClient())
 
 test('checkConsistency() resolves to correct response', async t => {
     t.deepEqual(
-        await checkConsistency(checkConsistencyCommand.transactions),
+        await checkConsistency(checkConsistencyCommand.tails),
         checkConsistencyResponse.state,
         'checkConsistency() should resolve to correct response'
     )
@@ -25,11 +25,11 @@ test('checkConsistency() rejects with correct errors for invalid transaction has
 })
 
 test.cb('checkConsistency() invokes callback', t => {
-    checkConsistency(checkConsistencyCommand.transactions, t.end)
+    checkConsistency(checkConsistencyCommand.tails, t.end)
 })
 
 test.cb('checkConsistency() passes correct arguments to callback', t => {
-    checkConsistency(checkConsistencyCommand.transactions, (err, res) => {
+    checkConsistency(checkConsistencyCommand.tails, (err, res) => {
         t.is(err, null, 'checkConsistency() should pass null as first argument in callback for successuful requests')
 
         t.deepEqual(

--- a/packages/core/test/integration/checkConsistency.test.ts
+++ b/packages/core/test/integration/checkConsistency.test.ts
@@ -1,7 +1,7 @@
 import test from 'ava'
 import { createHttpClient } from '@iota/http-client'
 import { createCheckConsistency } from '../../src'
-import { INVALID_HASH_ARRAY } from '../../src/errors'
+import { inconsistentTransaction, INVALID_HASH_ARRAY } from '../../src/errors'
 import {
     checkConsistencyCommand,
     checkConsistencyResponse,
@@ -35,7 +35,7 @@ test.cb(
         checkConsistency(checkConsistencyWithInfoCommand.tails, { rejectWithReason: true }, (err, state) => {
             t.is(
                 (err as Error).message,
-                checkConsistencyWithInfoResponse.info,
+                inconsistentTransaction(checkConsistencyWithInfoResponse.info),
                 'checkConsistency() should reject with correct info if state is `false` and called with `options = { rejectWithReason: true }`'
             )
 

--- a/packages/core/test/integration/checkConsistency.test.ts
+++ b/packages/core/test/integration/checkConsistency.test.ts
@@ -2,7 +2,12 @@ import test from 'ava'
 import { createHttpClient } from '@iota/http-client'
 import { createCheckConsistency } from '../../src'
 import { INVALID_HASH_ARRAY } from '../../src/errors'
-import { checkConsistencyCommand, checkConsistencyResponse } from './nocks/checkConsistency'
+import {
+    checkConsistencyCommand,
+    checkConsistencyResponse,
+    checkConsistencyWithInfoCommand,
+    checkConsistencyWithInfoResponse,
+} from './nocks/checkConsistency'
 
 const checkConsistency = createCheckConsistency(createHttpClient())
 
@@ -24,12 +29,27 @@ test('checkConsistency() rejects with correct errors for invalid transaction has
     )
 })
 
+test.cb(
+    'checkConsistency() rejects with correct info if state is `false` and called with `options = { rejectWithReason: true }`',
+    t => {
+        checkConsistency(checkConsistencyWithInfoCommand.tails, { rejectWithReason: true }, (err, state) => {
+            t.is(
+                (err as Error).message,
+                checkConsistencyWithInfoResponse.info,
+                'checkConsistency() should reject with correct info if state is `false` and called with `options = { rejectWithReason: true }`'
+            )
+
+            t.end()
+        })
+    }
+)
+
 test.cb('checkConsistency() invokes callback', t => {
-    checkConsistency(checkConsistencyCommand.tails, t.end)
+    checkConsistency(checkConsistencyCommand.tails, {}, t.end)
 })
 
 test.cb('checkConsistency() passes correct arguments to callback', t => {
-    checkConsistency(checkConsistencyCommand.tails, (err, res) => {
+    checkConsistency(checkConsistencyCommand.tails, {}, (err, res) => {
         t.is(err, null, 'checkConsistency() should pass null as first argument in callback for successuful requests')
 
         t.deepEqual(

--- a/packages/core/test/integration/nocks/checkConsistency.ts
+++ b/packages/core/test/integration/nocks/checkConsistency.ts
@@ -4,7 +4,7 @@ import headers from './headers'
 
 export const checkConsistencyCommand: CheckConsistencyCommand = {
     command: IRICommand.CHECK_CONSISTENCY,
-    transactions: ['A'.repeat(81), 'B'.repeat(81)],
+    tails: ['A'.repeat(81), 'B'.repeat(81)],
 }
 
 export const checkConsistencyResponse: CheckConsistencyResponse = {

--- a/packages/core/test/integration/nocks/checkConsistency.ts
+++ b/packages/core/test/integration/nocks/checkConsistency.ts
@@ -9,9 +9,25 @@ export const checkConsistencyCommand: CheckConsistencyCommand = {
 
 export const checkConsistencyResponse: CheckConsistencyResponse = {
     state: true,
+    info: '',
 }
 
 export const checkConsistencyNock = nock('http://localhost:14265', headers)
     .persist()
     .post('/', checkConsistencyCommand)
     .reply(200, checkConsistencyResponse)
+
+export const checkConsistencyWithInfoCommand: CheckConsistencyCommand = {
+    command: IRICommand.CHECK_CONSISTENCY,
+    tails: ['A'.repeat(81), 'B'.repeat(81), 'C'.repeat(81)],
+}
+
+export const checkConsistencyWithInfoResponse: CheckConsistencyResponse = {
+    state: false,
+    info: 'test response',
+}
+
+export const checkConsistencyWithInfoNock = nock('http://localhost:14265', headers)
+    .persist()
+    .post('/', checkConsistencyWithInfoCommand)
+    .reply(200, checkConsistencyWithInfoResponse)

--- a/packages/types.ts
+++ b/packages/types.ts
@@ -136,6 +136,7 @@ export interface CheckConsistencyCommand extends BaseCommand {
 
 export interface CheckConsistencyResponse {
     readonly state: boolean
+    readonly info: string
 }
 
 export interface FindTransactionsQuery {

--- a/packages/types.ts
+++ b/packages/types.ts
@@ -131,7 +131,7 @@ export type BroadcastTransactionsResponse = void
 
 export interface CheckConsistencyCommand extends BaseCommand {
     command: IRICommand.CHECK_CONSISTENCY
-    readonly transactions: ReadonlyArray<Hash>
+    readonly tails: ReadonlyArray<Hash>
 }
 
 export interface CheckConsistencyResponse {


### PR DESCRIPTION
# Description

- Fixes wrong `tails` field in `checkConsistency` command.
- Add `info` field in `CheckConsistencyResponse` type.
- Optionally uses `info` field as error message in case state is `false` and `rejectWithReason: true`.
- `promoteTransaction` calls `checkConsistency` with `rejectWithReason: true` by default, to propagate error message from `info` field.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (non-braeking change that adds functionality)

# How Has This Been Tested?
- [x] Tested with unit tests
- [x] Manually tested in integration with iri

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have updated the relevant documentation
- [x] New and existing unit tests pass locally with my changes

