### PR TITLE
checkConsistency: optionally reject with reason if state is false

### DIFF
--- a/lib/api/api.js
+++ b/lib/api/api.js
@@ -1978,7 +1978,7 @@ api.prototype.isPromotable = function(tail, options) {
               reject(err)
             }
             if (!res.state && options.rejectWithReason) {
-              reject(res.info)
+              reject('Transaction is inconsistent. Reason: ' + res.info)
             }
             resolve(res.state);
         });

--- a/lib/api/api.js
+++ b/lib/api/api.js
@@ -653,11 +653,14 @@ api.prototype.sendTransfer = function(seed, depth, minWeightMagnitude, transfers
 */
 api.prototype.promoteTransaction = function(tail, depth, minWeightMagnitude, transfer, params, callback) {
     var self = this;
+
+    if (!params) params = {}
+
     if (!inputValidator.isHash(tail)) {
         return callback(errors.invalidTrytes());
     }
 
-    self.isPromotable(tail).then(function (isPromotable) {
+    self.isPromotable(tail, { rejectWithReason: params.rejectWithReason || false }).then(function (isPromotable) {
       if (!isPromotable) {
         return callback(errors.inconsistentSubtangle(tail));
       }
@@ -1957,8 +1960,10 @@ api.prototype.isReattachable = function(inputAddresses, callback) {
 /*
  * Wraps {checkConsistency} in a promise so that its value is returned
  */
-api.prototype.isPromotable = function(tail) {
+api.prototype.isPromotable = function(tail, options) {
     var self = this;
+
+    if (!options) options = {}
 
     // Check if is hash
     if (!inputValidator.isHash(tail)) {
@@ -1967,16 +1972,16 @@ api.prototype.isPromotable = function(tail) {
 
     var command = apiCommands.checkConsistency([tail]);
 
-    var promise = new Promise(function(res, rej) {
-        self.sendCommand(command, function(err, isConsistent) {
+    return new Promise(function(resolve, reject) {
+        self.sendCommand(command, function(err, res) {
             if (err) {
-              rej(err)
+              reject(err)
             }
-            res(isConsistent);
+            if (!res.state && options.rejectWithReason) {
+              reject(res.info)
+            }
+            resolve(res.state);
         });
-    });
-    return promise.then(function(val) {
-        return val;
     });
 }
 

--- a/lib/utils/makeRequest.js
+++ b/lib/utils/makeRequest.js
@@ -322,8 +322,7 @@ makeRequest.prototype.prepareResult = function(result, requestCommand, callback)
         'getTrytes'             :   'trytes',
         'getInclusionStates'    :   'states',
         'attachToTangle'        :   'trytes',
-        'wereAddressesSpentFrom':   'states',
-        'checkConsistency'      :   'state'
+        'wereAddressesSpentFrom':   'states'
     }
 
     var error;


### PR DESCRIPTION
# Description

- Add `info` field in `CheckConsistencyResponse` type.
- Optionally uses `info` field as error message in case state is `false` and `rejectWithReason: true` option is set to true.
- `promoteTransaction` calls `checkConsistency` with `rejectWithReason: true` by default, to propagate error message from `info` field.

Related PR for `next` branch & `@iota/core`: https://github.com/iotaledger/iota.lib.js/pull/251

## Type of change

- [x] Enhancement (non-breaking change which adds functionality)

## Open questions

- [ ] `rejectWithReason` was first name I thought of. Any better ideas are welcome!

# How Has This Been Tested?

- [x] Manually tested with IRI

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
