### PR TITLE
Transaction hash validators [next branch]

### DIFF
--- a/packages/validators/package.json
+++ b/packages/validators/package.json
@@ -45,5 +45,9 @@
     "repository": {
         "type": "git",
         "url": "https://github.com/iotaledger/iota.js.git/tree/develop/packages/crypto"
+    },
+    "dependencies": {
+        "@iota/converter": "^1.0.0-alpha.1",
+        "@iota/transaction-converter": "^1.0.0-alpha.1"
     }
 }

--- a/packages/validators/src/validators.ts
+++ b/packages/validators/src/validators.ts
@@ -1,7 +1,8 @@
 /**
  * @module validators
  */
-
+import { tritsToTrytes, trytesToTrits, value, trytes } from '@iota/converter'
+import { transactionHash, asTransactionTrytes } from '@iota/transaction-converter'
 import { HASH_SIZE, TAG_SIZE, TRANSACTION_TRYTES_SIZE } from './constants'
 import * as errors from './errors'
 import { Address, Hash, Tag, Transaction, Transfer, Trytes } from '../../types'
@@ -105,11 +106,24 @@ export const isHash = (hash: any): hash is Hash =>
  *
  * @method isTransactionHash
  *
- * @param {string} hash
+ * @param {Hash|Transaction} input
  *
  * @return {boolean}
  */
-export const isTransactionHash = (hash: any): hash is Hash => isTrytesOfExactLength(hash, HASH_SIZE)
+export const isTransactionHash = (input: Hash | Transaction, mwm?: number): boolean => {
+    const hasCorrectMwm = (hash: Hash) =>
+        mwm
+            ? trytesToTrits(hash)
+                  .slice(-Math.abs(mwm))
+                  .every(trit => trit === 0)
+            : true
+
+    if (isTransaction(input)) {
+        return input.hash === transactionHash(trytesToTrits(asTransactionTrytes(input))) && hasCorrectMwm(input.hash)
+    }
+
+    return isTrytesOfExactLength(input, HASH_SIZE) && hasCorrectMwm(input)
+}
 
 /**
  * Checks if input contains `9`s only.

--- a/packages/validators/test/isTransactionHash.test.ts
+++ b/packages/validators/test/isTransactionHash.test.ts
@@ -1,9 +1,54 @@
 import test from 'ava'
+import { transactionObject, invalidTransactionObject } from '@iota/samples'
 import { isTransactionHash } from '../src'
 
 test('isTransactionHash() returns true for valid transaction hash.', t => {
     const hash = 'OZQCYCGHUJHNLDUOKXUPEDCDJCPEWEDXFAFPCGKKDVHVTGUEKBW9VUYDUVEAPZZGPHYMVHABOWZHA9999'
     t.is(isTransactionHash(hash), true, 'isTransactionHash() should return true for valid transaction hash.')
+})
+
+test('isTransactionHash() returns true for valid transaction', t => {
+    t.is(isTransactionHash(transactionObject), true, 'isTransactionHash() returns true for valid transaction')
+})
+
+test('isTransactionHash() returns true if provided transaction.hash is valid and minWeightMagnitude <= weightMagnitude.', t => {
+    t.is(
+        isTransactionHash(transactionObject, 4),
+        true,
+        'isTransactionHash() returns true if provided transaction.hash is valid and minWeightMagnitude <= weightMagnitude.'
+    )
+})
+
+test('isTransactionHash() returns false if provided transaction.hash is invalid and minWeightMagnitude > weightMagnitude.', t => {
+    t.is(
+        isTransactionHash(transactionObject, 5),
+        false,
+        'isTransactionHash() returns false if provided transaction.hash is invalid and minWeightMagnitude > weightMagnitude.'
+    )
+})
+
+test('isTransactionHash() returns true if provided hash is valid and minWeightMagnitude <= weightMagnitude.', t => {
+    t.is(
+        isTransactionHash(transactionObject.hash, 3),
+        true,
+        'isTransactionHash() returns true if provided hash is valid and minWeightMagnitude <= weightMagnitude.'
+    )
+})
+
+test('isTransactionHash() returns false if provided hash is invalid and minWeightMagnitude <= weightMagnitude.', t => {
+    t.is(
+        isTransactionHash('9'.repeat(80), 3),
+        false,
+        'isTransactionHash() returns false if provided hash is invalid and minWeightMagnitude <= weightMagnitude.'
+    )
+})
+
+test('isTransactionHash() returns false if provided hash is valid and minWeightMagnitude > weightMagnitude.', t => {
+    t.is(
+        isTransactionHash(transactionObject.hash, 5),
+        false,
+        'isTransactionHash() returns false if provided hash is valid and minWeightMagnitude > weightMagnitude.'
+    )
 })
 
 test('isTransactionHash() returns false for invalid transaction hash.', t => {

--- a/packages/validators/test/isTransactionHashArray.test.ts
+++ b/packages/validators/test/isTransactionHashArray.test.ts
@@ -10,7 +10,7 @@ test('isTransactionHashArray() returns true for valid transaction hashes.', t =>
     )
 })
 
-test('isTransactionHash() returns false for invalid transaction hashes.', t => {
+test('isTransactionHashArray() returns false for invalid transaction hashes.', t => {
     const invalidLength = ['OZQCYCGHUJHNLDUOKXUPEDCDJCPEWEDXFAFPCGKKDVHVTGUEKBW9VUYDUVEAPZZGPHYMVHABOWZHA9999ASDFASDFA']
     const invalidTrytes = ['sadfYCGHUJHNLDUOKXUPEDCDJCPEWEDXFAFPCGKKDVHVTGUEKBW9VUYDUVEAPZZGPHYMVHABOWZHA9999']
 


### PR DESCRIPTION
# Description

Updated `isTransactionHash`

- Provided with a hash as an input and `mwm`, it validates number of trailing zeros

Adds `isTransactionTrytes`

- Provided with transaction trytes as an input and `mwm`, it computes the hash and validates number of trailing zeros

Fixes https://github.com/iotaledger/iota.lib.js/issues/253

Related PR: https://github.com/iotaledger/iota.lib.js/pull/254

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix

# How Has This Been Tested?

- Added unit tests for `isTransactionHash`

# Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes