### PR TITLE
Retry with larger depth if reference transaction is too old

### DIFF
--- a/README.md
+++ b/README.md
@@ -401,7 +401,11 @@ iota.api.sendTrytes(trytes, depth, minWeightMagnitude, callback)
 1. **`trytes`** `Array` trytes
 2. **`depth`** `Int` depth value that determines how far to go for tip selection
 3. **`minWeightMagnitude`** `Int` minWeightMagnitude
-4. **`callback`**: `Function` Optional callback.
+4. **`options`** `Object` Optional parameters
+  - **`reference`**: `string` Reference transaction hash, to be used in tip selection.
+  - **`adjustDepth`**: `boolean` Flag to enable recovery by incrementing the `depth`, up to `maxDepth`, if original was too small.
+  - **`maxDepth`**: `number` Max depth, defaults to `15`
+5. **`callback`**: `Function` Optional callback.
 
 #### Returns
 `Array` - returns an array of the transfer (transaction objects).
@@ -428,6 +432,9 @@ iota.api.sendTransfer(seed, depth, minWeightMagnitude, transfers [, options], ca
 5. **`options`**: `Object` which is optional:
   - **`inputs`**: `Array` List of inputs used for funding the transfer
   - **`address`**: `String` if defined, this address will be used for sending the remainder value (of the inputs) to.
+  - **`reference`**: `String` Reference transaction hash, to be used in tip selection.
+  - **`adjustDepth`**: `boolean` Flag to enable recovery by incrementing the `depth`, up to `maxDepth`, if original was too small.
+  - **`maxDepth`**: `number` Max depth, defaults to `15`
 6. **`callback`**: `Function` Optional callback.
 
 
@@ -458,6 +465,7 @@ iota.api.promoteTransaction(transaction, depth, minWeightMagnitude, transfers [,
 5. **`params`** `Object` Params
   - **`delay`** `int` Delay between promotion transfers
   - **`interrupt`** `Boolean || Function` Flag to terminate promotion, can be boolean or a function returning a boolean
+  - **`maxDepth`** `number` Max depth, defaults to `15`
 6. **`callback`** `Function` Callback
 
 #### Returns

--- a/lib/api/api.js
+++ b/lib/api/api.js
@@ -299,14 +299,30 @@ api.prototype.getTips = function(callback) {
     return this.sendCommand(command, callback)
 }
 
+var MAX_DEPTH = 15
+var REFERENCE_TRANSACTION_TOO_OLD = 'reference transaction is too old'
+
 /**
 *   @method getTransactionsToApprove
 *   @param {int} depth
-*   @param {string} reference
+*   @param {string|object} [options] - Reference transaction hash or options object
+*   @param {string} [options.reference] - Reference transaction hash
+*   @param {number} [options.adjustDepth=false] - Flag to re-adjust depth, if original is too small
+*   @param {number} [options.maxDepth=15] - Max depth
 *   @returns {function} callback
 *   @returns {object} success
 **/
-api.prototype.getTransactionsToApprove = function(depth, reference, callback) {
+api.prototype.getTransactionsToApprove = function(depth, options, callback) {
+    var self = this
+
+    if (typeof arguments[1] === 'function') {
+      callback = options
+      options = {}
+    }
+
+    var reference = typeof arguments[1] === 'string' ? options : options.reference
+    var maxDepth = options.maxDepth || MAX_DEPTH
+    var adjustDepth = options.adjustDepth || false
 
     // Check if correct depth
     if (!inputValidator.isValue(depth)) {
@@ -316,7 +332,17 @@ api.prototype.getTransactionsToApprove = function(depth, reference, callback) {
 
     var command = apiCommands.getTransactionsToApprove(depth, reference);
 
-    return this.sendCommand(command, callback)
+    return this.sendCommand(command, function (err, tips) {
+      if (adjustDepth && err && err.message.indexOf(REFERENCE_TRANSACTION_TOO_OLD) > -1 && ++depth <= maxDepth) {
+        return self.getTransactionsToApprove(depth, {
+          reference: reference,
+          adjustDepth: adjustDepth,
+          maxDepth: maxDepth
+        }, callback)
+      }
+
+      callback(err, tips)
+    })
 }
 
 /**
@@ -527,7 +553,7 @@ api.prototype.sendTrytes = function(trytes, depth, minWeightMagnitude, options, 
     }
 
     // Get branch and trunk
-    self.getTransactionsToApprove(depth, options.reference, function(error, toApprove) {
+    self.getTransactionsToApprove(depth, options, function(error, toApprove) {
 
         if (error) {
             return callback(error)
@@ -660,15 +686,15 @@ api.prototype.promoteTransaction = function(tail, depth, minWeightMagnitude, tra
         return callback(errors.invalidTrytes());
     }
 
-    self.isPromotable(tail, { rejectWithReason: params.rejectWithReason || false }).then(function (isPromotable) {
-      if (!isPromotable) {
-        return callback(errors.inconsistentSubtangle(tail));
-      }
-
+    self.isPromotable(tail, { rejectWithReason: true }).then(function (isPromotable) {
       if (params.interrupt === true || (typeof(params.interrupt) === 'function' && params.interrupt()))
         return callback(null, tail);
 
-      self.sendTransfer(transfer[0].address, depth, minWeightMagnitude, transfer, {reference: tail}, function(err, res) {
+      self.sendTransfer(transfer[0].address, depth, minWeightMagnitude, transfer, {
+          reference: tail,
+          adjustDepth: true,
+          maxDepth: params.maxDepth
+      }, function(err, res) {
           if (err == null && params.delay > 0) {
               setTimeout (function() {
                   self.promoteTransaction(tail, depth, minWeightMagnitude, transfer, params, callback);
@@ -1978,7 +2004,7 @@ api.prototype.isPromotable = function(tail, options) {
               reject(err)
             }
             if (!res.state && options.rejectWithReason) {
-              reject('Transaction is inconsistent. Reason: ' + res.info)
+              reject(new Error('Transaction is inconsistent. Reason: ' + res.info))
             }
             resolve(res.state);
         });


### PR DESCRIPTION

# Description

If `getTransactionsToApprove()` is called with an old reference in relation to a given depth, the call will sometimes fail with [`"Reference transaction is too old"`](https://github.com/iotaledger/iri/blob/06ad631a438b07e932ea3de58ffac6e4c5b6e74b/src/main/java/com/iota/iri/service/tipselection/impl/TipSelectorImpl.java#L123) exception.

This PR addresses this issue by adding `adjustDepth` option to `getTransactionsToApprove`. This feature is now utilized by default in `promoteTransaction()`. If the option is set to true, `depth` is incremented upon failure, up to `maxDepth` (which is currently `15`).

Fixes #264 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (non-breaking change which adds functionality)

# How Has This Been Tested?

- [x] Promoting transaction and observing `depth` in `getTransactionsToApprove` requests.
- [x] Manually tested `sendTransfer`/`sendTrytes`


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
