### PR TITLE
Optional message & tag fields in transfer object

### DIFF
--- a/packages/core/src/createPrepareTransfers.ts
+++ b/packages/core/src/createPrepareTransfers.ts
@@ -132,16 +132,16 @@ export const createPrepareTransfers = (provider?: Provider, now: () => number = 
     ): Promise<ReadonlyArray<Trytes>> {
         if (caller !== 'lib') {
             if (options.address) {
+                /* tslint:disable-next-line:no-console */
                 console.warn(
-                    '`options.address` is deprecated and will be removed in v2.0.0. \n' +
-                        'Use `options.remainderAddress` instead.'
+                    '`options.address` is deprecated and will be removed in v2.0.0. Use `options.remainderAddress` instead.'
                 )
             }
 
             if (isTrytes(seed) && seed.length < 81) {
+                /* tslint:disable-next-line:no-console */
                 console.warn(
-                    'WARNING: Seeds with less length than 81 trytes are not secure! \n' +
-                        'Use a random, 81-trytes long seed!'
+                    'WARNING: Seeds with less length than 81 trytes are not secure! Use a random, 81-trytes long seed!'
                 )
             }
         }
@@ -151,7 +151,11 @@ export const createPrepareTransfers = (provider?: Provider, now: () => number = 
                 transactions: [],
                 trytes: [],
                 seed,
-                transfers,
+                transfers: transfers.map(transfer => ({
+                    ...transfer,
+                    message: transfer.message || '',
+                    tag: transfer.tag || '',
+                })),
                 timestamp: Math.floor((typeof now === 'function' ? now() : Date.now()) / 1000),
                 ...getPrepareTransfersOptions(options),
             })
@@ -213,7 +217,7 @@ export const addTransfers = (props: PrepareTransfersProps): PrepareTransfersProp
     return {
         ...props,
         transactions: transfers.reduce((acc, { address, value, tag, message }) => {
-            const length = Math.ceil((message.length || 1) / SIGNATURE_MESSAGE_FRAGMENT_LENGTH)
+            const length = Math.ceil(((message || '').length || 1) / SIGNATURE_MESSAGE_FRAGMENT_LENGTH)
 
             return addEntry(acc, {
                 address: removeChecksum(address),
@@ -224,7 +228,7 @@ export const addTransfers = (props: PrepareTransfersProps): PrepareTransfersProp
                 signatureMessageFragments: Array(length)
                     .fill('')
                     .map((_, i) =>
-                        message.slice(
+                        (message || '').slice(
                             i * SIGNATURE_MESSAGE_FRAGMENT_LENGTH,
                             (i + 1) * SIGNATURE_MESSAGE_FRAGMENT_LENGTH
                         )

--- a/packages/core/src/createPromoteTransaction.ts
+++ b/packages/core/src/createPromoteTransaction.ts
@@ -25,7 +25,7 @@ export const spammer = (): Transfer => ({
     message: '9'.repeat(27 * 81),
 })
 
-export const generateSpam = (n: number = 1) => new Array(n).map(spammer)
+export const generateSpam = (n: number = 1): ReadonlyArray<Transfer> => new Array(n).map(spammer)
 
 /**
  * @method createPromoteTransaction
@@ -72,10 +72,10 @@ export const createPromoteTransaction = (provider: Provider, attachFn?: AttachTo
         tailTransaction: string,
         depth: number,
         minWeightMagnitude: number,
-        spamTransfers: Transfer[] = generateSpam(),
+        spamTransfers: ReadonlyArray<Transfer> = generateSpam(),
         options?: Partial<PromoteTransactionOptions>,
-        callback?: Callback<Transaction[]>
-    ): Bluebird<Maybe<Transaction[]>> {
+        callback?: Callback<ReadonlyArray<Transaction>>
+    ): Bluebird<Maybe<ReadonlyArray<Transaction>>> {
         // Switch arguments
         if (typeof options === 'undefined') {
             options = {}
@@ -121,7 +121,7 @@ export const createPromoteTransaction = (provider: Provider, attachFn?: AttachTo
                         })
                     }, delay)
                 } else {
-                    return spamTransactions
+                    return [...spamTransactions]
                 }
             })
             .asCallback(typeof arguments[4] === 'function' ? arguments[4] : callback)

--- a/packages/core/src/createSendTransfer.ts
+++ b/packages/core/src/createSendTransfer.ts
@@ -16,7 +16,7 @@ export const createSendTransfer = (provider: Provider, attachFn?: AttachToTangle
         seed: string,
         depth: number,
         minWeightMagnitude: number,
-        transfers: Transfer[],
+        transfers: ReadonlyArray<Transfer>,
         options?: SendTransferOptions,
         callback?: Callback<Bundle>
     ): Promise<Bundle> {

--- a/packages/core/test/integration/prepareTransfers.test.ts
+++ b/packages/core/test/integration/prepareTransfers.test.ts
@@ -33,7 +33,6 @@ const transfers: ReadonlyArray<Transfer> = [
         address: addChecksum('B'.repeat(81)),
         value: 3,
         tag: 'TAG',
-        message: '',
     },
 ]
 

--- a/packages/multisig/src/multisig.ts
+++ b/packages/multisig/src/multisig.ts
@@ -39,6 +39,7 @@ export const sanitizeTransfers = (transfers: ReadonlyArray<Transfer>): ReadonlyA
         address: removeChecksum(transfer.address),
     }))
 
+/* tslint:disable:variable-name */
 export const createBundle = (
     input: MultisigInput,
     transfers: ReadonlyArray<Transfer>,
@@ -58,9 +59,9 @@ export const createBundle = (
         let signatureMessageLength = 1
 
         // If message longer than 2187 trytes, increase signatureMessageLength (add multiple transactions)
-        if (transfers[i].message.length > 2187) {
+        if ((transfers[i].message || '').length > 2187) {
             // Get total length, message / maxLength (2187 trytes)
-            signatureMessageLength += Math.floor(transfers[i].message.length / 2187)
+            signatureMessageLength += Math.floor((transfers[i].message || '').length / 2187)
 
             let msgCopy = transfers[i].message
 
@@ -81,7 +82,7 @@ export const createBundle = (
             let fragment = ''
 
             if (transfers[i].message) {
-                fragment = transfers[i].message.slice(0, 2187)
+                fragment = (transfers[i].message || '').slice(0, 2187)
             }
 
             for (let j = 0; fragment.length < 2187; j++) {
@@ -92,7 +93,7 @@ export const createBundle = (
         }
 
         // If no tag defined, get 27 tryte tag.
-        tag = transfers[i].tag ? transfers[i].tag : '9'.repeat(27)
+        tag = transfers[i].tag || '9'.repeat(27)
 
         // Pad for required 27 tryte length
         for (let j = 0; tag.length < 27; j++) {
@@ -305,7 +306,7 @@ export default class Multisig {
      */
     public addSignature(bundleToSign: Bundle, inputAddress: string, keyTrytes: string, callback: Callback) {
         const bundle = bundleToSign
-        const _bundle: Partial<Transaction>[] = []
+        const _bundle: Array<Partial<Transaction>> = []
 
         // Get the security used for the private key
         // 1 security level = 2187 trytes

--- a/packages/types.ts
+++ b/packages/types.ts
@@ -34,8 +34,8 @@ export interface Inputs {
 export interface Transfer {
     readonly address: string
     readonly value: number
-    readonly message: string
-    readonly tag: string
+    readonly message?: string
+    readonly tag?: string
     readonly obsoleteTag?: string
 }
 

--- a/packages/validators/src/validators.ts
+++ b/packages/validators/src/validators.ts
@@ -135,9 +135,8 @@ export const isTransfer = (transfer: Transfer): transfer is Transfer =>
     isHash(transfer.address) &&
     isInteger(transfer.value) &&
     transfer.value >= 0 &&
-    (!transfer.message.length || isTrytes(transfer.message)) &&
-    (!transfer.tag.length || isTrytes(transfer.tag)) &&
-    transfer.tag.length <= 27
+    (!transfer.message || isTrytes(transfer.message, '0,')) &&
+    (!transfer.tag || isTag(transfer.tag))
 
 /**
  * Checks if input is array of valid `transfer` objects.

--- a/packages/validators/test/isTransfer.test.ts
+++ b/packages/validators/test/isTransfer.test.ts
@@ -10,6 +10,26 @@ test('isTransfer() returns true for valid transfer.', t => {
     }
 
     t.is(isTransfer(transfer), true, 'isTransfer() should return true for valid transfer.')
+
+    t.is(
+        isTransfer({
+            ...transfer,
+            message: undefined,
+            tag: undefined,
+        }),
+        true,
+        'isTransfer() should return true for valid transfer with undefined optional fields.'
+    )
+
+    t.is(
+        isTransfer({
+            ...transfer,
+            message: '',
+            tag: '',
+        }),
+        true,
+        'isTransfer() should return true for valid transfer with empty optional fields.'
+    )
 })
 
 test('isTransfer() returns false for transfer with invalid address.', t => {


### PR DESCRIPTION
# Description

Makes `message` & `tag` fields of [transfer object](https://github.com/iotaledger/iota.lib.js/compare/next...chrisdukakis:fix/transfer-object?expand=1#diff-94ae1bf38dc25cd5698868b4719fa369) optional.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Updated tests to include vectors for [`undefined`](https://github.com/iotaledger/iota.lib.js/compare/next...chrisdukakis:fix/transfer-object?expand=1#diff-8fceba51e8323412fd72783bdf6d8544R17) & [empty (`""`)](https://github.com/iotaledger/iota.lib.js/compare/next...chrisdukakis:fix/transfer-object?expand=1#diff-8fceba51e8323412fd72783bdf6d8544R27) fields

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
