### PR TITLE
Populate accountData.transactions with hashes

### DIFF
--- a/packages/core/src/createGetAccountData.ts
+++ b/packages/core/src/createGetAccountData.ts
@@ -28,7 +28,7 @@ export interface AccountData {
     readonly addresses: ReadonlyArray<Hash>
     readonly inputs: ReadonlyArray<Address>
     readonly transfers: ReadonlyArray<Bundle>
-    readonly transactions: ReadonlyArray<Transaction>
+    readonly transactions: ReadonlyArray<Hash>
     readonly latestAddress: Hash
     readonly balance: number
 }
@@ -108,6 +108,7 @@ export const createGetAccountData = (provider: Provider, caller?: string) => {
         const { start, end, security } = getAccountDataOptions(options)
 
         if (caller !== 'lib') {
+            /* tslint:disable-next-line:no-console */
             console.warn(
                 '`AccountData.transfers` field is deprecated, and `AccountData.transactions` field should be used instead.\n' +
                     'Fetching of full bundles should be done lazily.'
@@ -139,12 +140,13 @@ export const createGetAccountData = (provider: Provider, caller?: string) => {
                 .then(addresses =>
                     Promise.all([
                         getBundlesFromAddresses(addresses, true),
+                        // findTransactions({ addresses }), // Find transactions instead of getBundlesFromAddress as of v2.0.0
                         getBalances(addresses, 100),
                         wereAddressesSpentFrom(addresses),
                         addresses,
                     ])
                 )
-                .then(([transfers, { balances }, spentStates, addresses]) => ({
+                .then(([transfers /* transactions */, { balances }, spentStates, addresses]) => ({
                     // 2. Assign the last address as the latest address
                     latestAddress: addresses[addresses.length - 1],
 
@@ -156,9 +158,16 @@ export const createGetAccountData = (provider: Provider, caller?: string) => {
                     // `findTransactions({ address })` in v2.0.0.
                     // Full bundles should be fetched lazily if there are relevant use cases...
                     transactions: transfers.reduce(
-                        (acc, bundle) => acc.concat(bundle.filter(({ address }) => addresses.indexOf(address) > -1)),
+                        (acc: ReadonlyArray<Hash>, bundle) =>
+                            acc.concat(
+                                bundle
+                                    .filter(({ address }) => addresses.indexOf(address) > -1)
+                                    .map(transaction => transaction.hash)
+                            ),
                         []
                     ),
+
+                    // transactions,
 
                     // 5. Add balances and extract inputs
                     inputs: addresses

--- a/packages/core/test/integration/getAccountData.test.ts
+++ b/packages/core/test/integration/getAccountData.test.ts
@@ -1,6 +1,7 @@
 import test from 'ava'
 import { createHttpClient } from '@iota/http-client'
 import { transfers } from '@iota/samples'
+import { Hash } from '../../../types'
 import { AccountData, createGetAccountData } from '../../src'
 import { INVALID_SEED, INVALID_START_END_OPTIONS } from '../../src/errors'
 import { getBalancesCommand, balancesResponse } from './nocks/getBalances'
@@ -40,7 +41,12 @@ const accountData: AccountData = {
     latestAddress: getBalancesCommand.addresses[2],
     transfers,
     transactions: transfers.reduce(
-        (acc, bundle) => acc.concat(bundle.filter(({ address }) => accountAddresses.indexOf(address) > -1)),
+        (acc: ReadonlyArray<Hash>, bundle) =>
+            acc.concat(
+                bundle
+                    .filter(({ address }) => accountAddresses.indexOf(address) > -1)
+                    .map(transaction => transaction.hash)
+            ),
         []
     ),
     balance: 10,


### PR DESCRIPTION
# Description

Populates `accountData.transactions` list with hashes.

In the future a single `findTransactions()` call will be used to improve performance.
This would require to remove the deprecated `transfers` field.

Fixes #166 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Updated integration tests


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
