### PR TITLE
Extract numbers from json-encoded fragments

### DIFF
--- a/api_reference.md
+++ b/api_reference.md
@@ -1617,7 +1617,8 @@ Supports the following forms of JSON encoded values:
 - `"{ \"message\": \"hello\" }"\`
 - `"[1, 2, 3]"`
 - `"true"`, `"false"` & `"null"`
-- `"\"hello\""`
+- `"\"hello\""
+- `123`
 
 **Example**  
 ```js

--- a/packages/extract-json/README.md
+++ b/packages/extract-json/README.md
@@ -31,7 +31,8 @@ Supports the following forms of JSON encoded values:
 - `"{ \"message\": \"hello\" }"\`
 - `"[1, 2, 3]"`
 - `"true"`, `"false"` & `"null"`
-- `"\"hello\""`
+- `"\"hello\""
+- `123`
 
 **Example**  
 ```js

--- a/packages/extract-json/test/extractJson.test.ts
+++ b/packages/extract-json/test/extractJson.test.ts
@@ -90,6 +90,86 @@ test('extraJson() parses null.', t => {
     )
 })
 
+test('extractJson() parses numbers', t => {
+    t.is(
+        extractJson(
+            bundleWithEmptyJSON
+                .map(tx => ({
+                    ...tx,
+                    signatureMessageFragment: 'XA' + '9'.repeat(81 * 27 - 2),
+                }))
+                .slice(0, 1)
+        ),
+        3,
+        'extractJson() should parse integers'
+    )
+
+    t.is(
+        extractJson(
+            bundleWithEmptyJSON
+                .map(tx => ({
+                    ...tx,
+                    signatureMessageFragment: 'RAXA' + '9'.repeat(81 * 27 - 2),
+                }))
+                .slice(0, 1)
+        ),
+        -3,
+        'extractJson() should parse negative integers'
+    )
+
+    t.is(
+        extractJson(
+            bundleWithEmptyJSON
+                .map(tx => ({
+                    ...tx,
+                    signatureMessageFragment: 'XASAVAYA' + '9'.repeat(81 * 27 - 8),
+                }))
+                .slice(0, 1)
+        ),
+        3.14,
+        'extractJson() should parse positive floats'
+    )
+
+    t.is(
+        extractJson(
+            bundleWithEmptyJSON
+                .map(tx => ({
+                    ...tx,
+                    signatureMessageFragment: 'PAXASAVAYA' + '9'.repeat(81 * 27 - 10),
+                }))
+                .slice(0, 1)
+        ),
+        3.14,
+        'extractJson() should parse positive floats (with sign)'
+    )
+
+    t.is(
+        extractJson(
+            bundleWithEmptyJSON
+                .map(tx => ({
+                    ...tx,
+                    signatureMessageFragment: 'RAXASAVAYA' + '9'.repeat(81 * 27 - 10),
+                }))
+                .slice(0, 1)
+        ),
+        -3.14,
+        'extractJson() should parse negative floats'
+    )
+
+    t.is(
+        extractJson(
+            bundleWithEmptyJSON
+                .map(tx => ({
+                    ...tx,
+                    signatureMessageFragment: 'VASAWAXATCPAZA' + '9'.repeat(81 * 27 - 14),
+                }))
+                .slice(0, 1)
+        ),
+        123000,
+        'extractJson() should parse exponential'
+    )
+})
+
 test('extractJson() throws error for invalid bundle.', t => {
     t.is(
         t.throws(() => extractJson([]), Error).message,


### PR DESCRIPTION
# Description

Adds support for number extraction in [`@iota/extract-json`] according to: https://github.com/iotaledger/iota.lib.js/issues/231#issuecomment-402383449

Thanks @obany for this nice fix!

Fixes #231 

## Type of change

- [x] Enhancement (non-breaking change which adds functionality)

# How Has This Been Tested?
- [x] [Unit tests](https://github.com/chrisdukakis/iota.lib.js/blob/2b00a572b85f40cb01ce3b2209e7cc44c1280bf3/packages/extract-json/test/extractJson.test.ts#L93)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
