### PR TITLE
Feat: Rename MilestonePayload lastMilestoneId field to previousMilestoneId

### DIFF
--- a/packages/iota/docs/interfaces/IMilestonePayload.md
+++ b/packages/iota/docs/interfaces/IMilestonePayload.md
@@ -15,7 +15,7 @@ Milestone payload.
 - [type](IMilestonePayload.md#type)
 - [index](IMilestonePayload.md#index)
 - [timestamp](IMilestonePayload.md#timestamp)
-- [lastMilestoneId](IMilestonePayload.md#lastmilestoneid)
+- [previousMilestoneId](IMilestonePayload.md#previousMilestoneId)
 - [parentMessageIds](IMilestonePayload.md#parentmessageids)
 - [confirmedMerkleRoot](IMilestonePayload.md#confirmedmerkleroot)
 - [appliedMerkleRoot](IMilestonePayload.md#appliedmerkleroot)
@@ -53,11 +53,11 @@ The timestamp of the milestone.
 
 ___
 
-### lastMilestoneId
+### previousMilestoneId
 
-• **lastMilestoneId**: `string`
+• **previousMilestoneId**: `string`
 
-The timestamp of the milestone.
+The id of the previous milestone.
 
 ___
 

--- a/packages/iota/src/binary/payloads/milestonePayload.ts
+++ b/packages/iota/src/binary/payloads/milestonePayload.ts
@@ -51,7 +51,7 @@ export function deserializeMilestonePayload(readStream: ReadStream): IMilestoneP
     }
     const index = readStream.readUInt32("payloadMilestone.index");
     const timestamp = readStream.readUInt32("payloadMilestone.timestamp");
-    const lastMilestoneId = readStream.readFixedHex("payloadMilestone.lastMilestoneId", MESSAGE_ID_LENGTH);
+    const previousMilestoneId = readStream.readFixedHex("payloadMilestone.previousMilestoneId", MESSAGE_ID_LENGTH);
     const numParents = readStream.readUInt8("payloadMilestone.numParents");
     const parentMessageIds: string[] = [];
 
@@ -78,7 +78,7 @@ export function deserializeMilestonePayload(readStream: ReadStream): IMilestoneP
         type: MILESTONE_PAYLOAD_TYPE,
         index,
         timestamp: Number(timestamp),
-        lastMilestoneId,
+        previousMilestoneId,
         parentMessageIds,
         confirmedMerkleRoot,
         appliedMerkleRoot,
@@ -99,9 +99,9 @@ export function serializeMilestonePayload(writeStream: WriteStream, object: IMil
     writeStream.writeUInt32("payloadMilestone.timestamp", object.timestamp);
 
     writeStream.writeFixedHex(
-        "payloadMilestone.lastMilestoneId",
+        "payloadMilestone.previousMilestoneId",
         MESSAGE_ID_LENGTH,
-        object.lastMilestoneId
+        object.previousMilestoneId
     );
 
     if (object.parentMessageIds.length < MIN_NUMBER_PARENTS) {

--- a/packages/iota/src/models/payloads/IMilestonePayload.ts
+++ b/packages/iota/src/models/payloads/IMilestonePayload.ts
@@ -24,9 +24,9 @@ export interface IMilestonePayload extends ITypeBase<7> {
     timestamp: number;
 
     /**
-     * The timestamp of the milestone.
+     * The id of the previous milestone.
      */
-    lastMilestoneId: string;
+    previousMilestoneId: string;
 
     /**
      * The parents where this milestone attaches to.

--- a/packages/iota/src/utils/logging.ts
+++ b/packages/iota/src/utils/logging.ts
@@ -249,7 +249,7 @@ export function logMilestonePayload(prefix: string, payload?: IMilestonePayload)
         logger(`${prefix}Milestone Payload`);
         logger(`${prefix}\tIndex:`, payload.index);
         logger(`${prefix}\tTimestamp:`, payload.timestamp);
-        logger(`${prefix}\tLastMilestoneId:`, payload.lastMilestoneId);
+        logger(`${prefix}\tPreviousMilestoneId:`, payload.previousMilestoneId);
         for (let i = 0; i < payload.parentMessageIds.length; i++) {
             logger(`${prefix}\tParent ${i + 1}:`, payload.parentMessageIds[i]);
         }

--- a/packages/iota/test/binary/message.spec.ts
+++ b/packages/iota/test/binary/message.spec.ts
@@ -81,7 +81,7 @@ describe("Binary Message", () => {
         expect(payload.type).toEqual(7);
         expect(payload.index).toEqual(23564);
         expect(payload.timestamp).toEqual(1650790571);
-        expect(payload.lastMilestoneId).toEqual("0x4b218eb12cc9d8577e092ec9b733da1a97768d7b13b6d005cd9c285305a9175f");
+        expect(payload.previousMilestoneId).toEqual("0x4b218eb12cc9d8577e092ec9b733da1a97768d7b13b6d005cd9c285305a9175f");
         expect(payload.parentMessageIds[0]).toEqual("0x0d34993b5485a59c9c54f04068ea2caf9f2f76c58228013f1ad03dd6dfc06829");
         expect(payload.parentMessageIds[1]).toEqual("0xce68b9feaa6f6df5eed44781a8c6881cd1d8910da905625dc20ca9986e85887b");
         expect(payload.parentMessageIds[2]).toEqual("0xd539f3c16201bd6935a8daaa2e6efc775a5722ca31287e7e7e92842db111454d");

--- a/packages/iota/test/binary/payloads/milestonePayload.spec.ts
+++ b/packages/iota/test/binary/payloads/milestonePayload.spec.ts
@@ -17,7 +17,7 @@ describe("Binary Milestone Payload", () => {
             type: MILESTONE_PAYLOAD_TYPE,
             index: 1087,
             timestamp: 1605190003,
-            lastMilestoneId: "0x50cf83f8ee3e316a7f3a4df32082747e8392e59fa724bbd13a9f2efc34cec6e4",
+            previousMilestoneId: "0x50cf83f8ee3e316a7f3a4df32082747e8392e59fa724bbd13a9f2efc34cec6e4",
             parentMessageIds: [
                 "0x04ba147c9cc9bebd3b97310a23d385f33d8e67ac42868b69bc06f5468e3c0a02",
                 "0xc0ab1d1f6886ba6317634da6b2d957e7c987a9699dd3707d1e2751fcf4b8efe3"
@@ -49,7 +49,7 @@ describe("Binary Milestone Payload", () => {
         expect(deserialized.type).toEqual(7);
         expect(deserialized.index).toEqual(1087);
         expect(deserialized.timestamp).toEqual(1605190003);
-        expect(deserialized.lastMilestoneId).toEqual("0x50cf83f8ee3e316a7f3a4df32082747e8392e59fa724bbd13a9f2efc34cec6e4");
+        expect(deserialized.previousMilestoneId).toEqual("0x50cf83f8ee3e316a7f3a4df32082747e8392e59fa724bbd13a9f2efc34cec6e4");
         expect(deserialized.parentMessageIds[0]).toEqual(
             "0x04ba147c9cc9bebd3b97310a23d385f33d8e67ac42868b69bc06f5468e3c0a02"
         );
@@ -87,7 +87,7 @@ describe("Binary Milestone Payload", () => {
             type: MILESTONE_PAYLOAD_TYPE,
             index: 1087,
             timestamp: 1605190003,
-            lastMilestoneId: "0x50cf83f8ee3e316a7f3a4df32082747e8392e59fa724bbd13a9f2efc34cec6e4",
+            previousMilestoneId: "0x50cf83f8ee3e316a7f3a4df32082747e8392e59fa724bbd13a9f2efc34cec6e4",
             parentMessageIds: [
                 "0x04ba147c9cc9bebd3b97310a23d385f33d8e67ac42868b69bc06f5468e3c0a02",
                 "0xc0ab1d1f6886ba6317634da6b2d957e7c987a9699dd3707d1e2751fcf4b8efe3"
@@ -147,7 +147,7 @@ describe("Binary Milestone Payload", () => {
         expect(deserialized.type).toEqual(7);
         expect(deserialized.index).toEqual(1087);
         expect(deserialized.timestamp).toEqual(1605190003);
-        expect(deserialized.lastMilestoneId).toEqual("0x50cf83f8ee3e316a7f3a4df32082747e8392e59fa724bbd13a9f2efc34cec6e4");
+        expect(deserialized.previousMilestoneId).toEqual("0x50cf83f8ee3e316a7f3a4df32082747e8392e59fa724bbd13a9f2efc34cec6e4");
         expect(deserialized.parentMessageIds[0]).toEqual(
             "0x04ba147c9cc9bebd3b97310a23d385f33d8e67ac42868b69bc06f5468e3c0a02"
         );
@@ -200,7 +200,7 @@ describe("Binary Milestone Payload", () => {
             type: MILESTONE_PAYLOAD_TYPE,
             index: 1087,
             timestamp: 1605190003,
-            lastMilestoneId: "0x50cf83f8ee3e316a7f3a4df32082747e8392e59fa724bbd13a9f2efc34cec6e4",
+            previousMilestoneId: "0x50cf83f8ee3e316a7f3a4df32082747e8392e59fa724bbd13a9f2efc34cec6e4",
             parentMessageIds: [
                 "0x04ba147c9cc9bebd3b97310a23d385f33d8e67ac42868b69bc06f5468e3c0a02",
                 "0xc0ab1d1f6886ba6317634da6b2d957e7c987a9699dd3707d1e2751fcf4b8efe3"
@@ -239,7 +239,7 @@ describe("Binary Milestone Payload", () => {
         expect(deserialized.type).toEqual(7);
         expect(deserialized.index).toEqual(1087);
         expect(deserialized.timestamp).toEqual(1605190003);
-        expect(deserialized.lastMilestoneId).toEqual("0x50cf83f8ee3e316a7f3a4df32082747e8392e59fa724bbd13a9f2efc34cec6e4");
+        expect(deserialized.previousMilestoneId).toEqual("0x50cf83f8ee3e316a7f3a4df32082747e8392e59fa724bbd13a9f2efc34cec6e4");
         expect(deserialized.parentMessageIds[0]).toEqual(
             "0x04ba147c9cc9bebd3b97310a23d385f33d8e67ac42868b69bc06f5468e3c0a02"
         );
@@ -284,7 +284,7 @@ describe("Binary Milestone Payload", () => {
             type: MILESTONE_PAYLOAD_TYPE,
             index: 1087,
             timestamp: 1605190003,
-            lastMilestoneId: "0x50cf83f8ee3e316a7f3a4df32082747e8392e59fa724bbd13a9f2efc34cec6e4",
+            previousMilestoneId: "0x50cf83f8ee3e316a7f3a4df32082747e8392e59fa724bbd13a9f2efc34cec6e4",
             parentMessageIds: [
                 "0x04ba147c9cc9bebd3b97310a23d385f33d8e67ac42868b69bc06f5468e3c0a02",
                 "0xc0ab1d1f6886ba6317634da6b2d957e7c987a9699dd3707d1e2751fcf4b8efe3"
@@ -349,7 +349,7 @@ describe("Binary Milestone Payload", () => {
         expect(deserialized.type).toEqual(7);
         expect(deserialized.index).toEqual(1087);
         expect(deserialized.timestamp).toEqual(1605190003);
-        expect(deserialized.lastMilestoneId).toEqual("0x50cf83f8ee3e316a7f3a4df32082747e8392e59fa724bbd13a9f2efc34cec6e4");
+        expect(deserialized.previousMilestoneId).toEqual("0x50cf83f8ee3e316a7f3a4df32082747e8392e59fa724bbd13a9f2efc34cec6e4");
         expect(deserialized.parentMessageIds[0]).toEqual(
             "0x04ba147c9cc9bebd3b97310a23d385f33d8e67ac42868b69bc06f5468e3c0a02"
         );

--- a/packages/iota/test/binary/payloads/payloads.spec.ts
+++ b/packages/iota/test/binary/payloads/payloads.spec.ts
@@ -109,7 +109,7 @@ describe("Binary Payload", () => {
         expect(payload.type).toEqual(7);
         expect(payload.index).toEqual(1087);
         expect(payload.timestamp).toEqual(1605190003);
-        expect(payload.lastMilestoneId).toEqual("0x50cf83f8ee3e316a7f3a4df32082747e8392e59fa724bbd13a9f2efc34cec6e4");
+        expect(payload.previousMilestoneId).toEqual("0x50cf83f8ee3e316a7f3a4df32082747e8392e59fa724bbd13a9f2efc34cec6e4");
         expect(payload.parentMessageIds[0]).toEqual("0xc0ab1d1f6886ba6317634da6b2d957e7c987a9699dd3707d1e2751fcf4b8efe3");
         expect(payload.parentMessageIds[1]).toEqual("0x04ba147c9cc9bebd3b97310a23d385f33d8e67ac42868b69bc06f5468e3c0a02");
         expect(payload.confirmedMerkleRoot).toEqual(


### PR DESCRIPTION
# Description of change

- Rename MilestonePayload lastMilestoneId field to previousMilestoneId

Solves https://github.com/iotaledger/iota.js/issues/841

## Type of change

- Breaking change

## Change checklist

- [x] My code follows the contribution guidelines for this project
