### PR TITLE
Fix: Change filter option governorBech32 type to string

### DIFF
--- a/packages/iota/src/clients/plugins/indexerPluginClient.ts
+++ b/packages/iota/src/clients/plugins/indexerPluginClient.ts
@@ -192,7 +192,7 @@ export class IndexerPluginClient {
      */
     public async aliases(filterOptions?: {
         stateControllerBech32?: string;
-        governorBech32?: boolean;
+        governorBech32?: string;
         issuerBech32?: string;
         senderBech32?: string;
         hasNativeTokens?: boolean;


### PR DESCRIPTION
# Description of change

Change filter option governorBech32 in indexerPlugin from boolean type to string.
fixes #900.

## Type of change

- Bug fix (a non-breaking change which fixes an issue)


## Change checklist

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
