### PR TITLE
Make fields in INodeInfoMilestone optional

### DIFF
--- a/packages/iota/src/models/info/INodeInfoMilesone.ts
+++ b/packages/iota/src/models/info/INodeInfoMilesone.ts
@@ -12,9 +12,9 @@ export interface INodeInfoMilestone {
     /**
      * The milestone timestamp.
      */
-    timestamp: number;
+    timestamp?: number;
     /**
      * The milestone id.
      */
-    milestoneId: string;
+    milestoneId?: string;
 }


### PR DESCRIPTION
Nodes omit these fields in the response when they are unhealthy and unsynced, therefore asking info from such a node would cause a client error (missing mandatory fields).
