### PR TITLE
Feat: Hex amount type

### DIFF
--- a/packages/iota/src/models/INativeToken.ts
+++ b/packages/iota/src/models/INativeToken.ts
@@ -13,5 +13,10 @@ export interface INativeToken {
     /**
      * Amount of native tokens of the given Token ID.
      */
-    amount: string;
+    amount: HexEncodedAmount;
 }
+
+/**
+ * Hex encoded U256.
+ */
+export type HexEncodedAmount = string;


### PR DESCRIPTION
# Description of change

Adding a hex amount type, so it's easier to differentiate between normal amounts and hex encoded amounts that both have the string type.
Related to https://github.com/iotaledger/wallet.rs/issues/1265

## Type of change

- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Change checklist

- [] My code follows the contribution guidelines for this project
- [] I have performed a self-review of my own code
- [] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
