### PR TITLE
Fix: Rename indexer outputs signature and query parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ async function run() {
     console.log("\tConfirmed Milestone Index:", info.status.confirmedMilestoneIndex);
     console.log("\tPruning Index:", info.status.pruningIndex);
     console.log("\tNetwork Name:", info.protocol.networkName);
-    console.log("\tBech32 HRP:", info.protocol.bech32HRP);
-    console.log("\tMin PoW Score:", info.protocol.minPoWScore);
+    console.log("\tBech32 HRP:", info.protocol.bech32Hrp);
+    console.log("\tMin PoW Score:", info.protocol.minPowScore);
     console.log("\tBlocks Per Second:", info.metrics.blocksPerSecond);
     console.log("\tReferenced Blocks Per Second:", info.metrics.referencedBlocksPerSecond);
     console.log("\tReferenced Rate:", info.metrics.referencedRate);

--- a/documentation/docs/getting_started.mdx
+++ b/documentation/docs/getting_started.mdx
@@ -64,7 +64,7 @@ async function run() {
     console.log("\tConfirmed Milestone Index:", info.confirmedMilestoneIndex);
     console.log("\tPruning Index:", info.pruningIndex);
     console.log("\tFeatures:", info.features);
-    console.log("\tMin PoW Score:", info.minPoWScore);
+    console.log("\tMin PoW Score:", info.minPowScore);
 }
 
 run()

--- a/documentation/docs/references/client/classes/IndexerPluginClient.md
+++ b/documentation/docs/references/client/classes/IndexerPluginClient.md
@@ -18,7 +18,7 @@ Indexer plugin which provides access to the indexer plugin API.
 
 ### Methods
 
-- [outputs](IndexerPluginClient.md#outputs)
+- [basicOutputs](IndexerPluginClient.md#basicOutputs)
 - [aliases](IndexerPluginClient.md#aliases)
 - [alias](IndexerPluginClient.md#alias)
 - [nfts](IndexerPluginClient.md#nfts)
@@ -43,7 +43,7 @@ Create a new instance of IndexerPluginClient.
 
 ## Methods
 
-### outputs
+### basicOutputs
 
 ▸ **outputs**(`filterOptions?`): `Promise`<[`IOutputsResponse`](../interfaces/IOutputsResponse.md)\>
 

--- a/documentation/docs/references/client/interfaces/IClient.md
+++ b/documentation/docs/references/client/interfaces/IClient.md
@@ -536,13 +536,13 @@ ___
 
 ### protocolInfo
 
-▸ **protocolInfo**(): `Promise`<{ `networkName`: `string` ; `networkId`: `string` ; `bech32HRP`: `string` ; `minPoWScore`: `number`  }\>
+▸ **protocolInfo**(): `Promise`<{ `networkName`: `string` ; `networkId`: `string` ; `bech32Hrp`: `string` ; `minPowScore`: `number`  }\>
 
 Get the protocol info from the node.
 
 #### Returns
 
-`Promise`<{ `networkName`: `string` ; `networkId`: `string` ; `bech32HRP`: `string` ; `minPoWScore`: `number`  }\>
+`Promise`<{ `networkName`: `string` ; `networkId`: `string` ; `bech32Hrp`: `string` ; `minPowScore`: `number`  }\>
 
 The protocol info.
 

--- a/documentation/docs/references/client/interfaces/INodeInfoProtocol.md
+++ b/documentation/docs/references/client/interfaces/INodeInfoProtocol.md
@@ -15,10 +15,10 @@ The Protocol Info.
 ### Properties
 
 - [networkName](INodeInfoProtocol.md#networkname)
-- [bech32HRP](INodeInfoProtocol.md#bech32hrp)
+- [bech32Hrp](INodeInfoProtocol.md#bech32hrp)
 - [tokenSupply](INodeInfoProtocol.md#tokensupply)
 - [protocolVersion](INodeInfoProtocol.md#protocolversion)
-- [minPoWScore](INodeInfoProtocol.md#minpowscore)
+- [minPowScore](INodeInfoProtocol.md#minpowscore)
 - [rentStructure](INodeInfoProtocol.md#rentstructure)
 
 ## Properties
@@ -31,9 +31,9 @@ The human friendly name of the network on which the node operates on.
 
 ___
 
-### bech32HRP
+### bech32Hrp
 
-• **bech32HRP**: `string`
+• **bech32Hrp**: `string`
 
 The human readable part of bech32 addresses.
 
@@ -55,9 +55,9 @@ The protocol version.
 
 ___
 
-### minPoWScore
+### minPowScore
 
-• **minPoWScore**: `number`
+• **minPowScore**: `number`
 
 The minimum score required for PoW.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@iota/workspaces",
-    "version": "1.9.0-stardust.5",
+    "version": "1.9.0-stardust.4",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@iota/workspaces",
-            "version": "1.9.0-stardust.5",
+            "version": "1.9.0-stardust.4",
             "license": "Apache-2.0",
             "workspaces": [
                 "packages/util",
@@ -8397,7 +8397,7 @@
         },
         "packages/iota": {
             "name": "@iota/iota.js",
-            "version": "1.9.0-stardust.24",
+            "version": "1.9.0-stardust.25",
             "license": "Apache-2.0",
             "dependencies": {
                 "@iota/crypto.js": "^1.9.0-stardust.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@iota/workspaces",
-    "version": "1.9.0-stardust.4",
+    "version": "1.9.0-stardust.5",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@iota/workspaces",
-            "version": "1.9.0-stardust.4",
+            "version": "1.9.0-stardust.5",
             "license": "Apache-2.0",
             "workspaces": [
                 "packages/util",
@@ -7525,9 +7525,9 @@
             }
         },
         "node_modules/terser": {
-            "version": "5.14.1",
-            "resolved": "https://registry.npmjs.org/terser/-/terser-5.14.1.tgz",
-            "integrity": "sha512-+ahUAE+iheqBTDxXhTisdA8hgvbEG1hHOQ9xmNjeUJSoi6DU/gMrKNcfZjHkyY6Alnuyc+ikYJaxxfHkT3+WuQ==",
+            "version": "5.14.2",
+            "resolved": "https://registry.npmjs.org/terser/-/terser-5.14.2.tgz",
+            "integrity": "sha512-oL0rGeM/WFQCUd0y2QrWxYnq7tfSuKBiqTjRPWrRgB46WD/kiwHwF8T23z78H6Q6kGCuuHcPB+KULHRdxvVGQA==",
             "dev": true,
             "dependencies": {
                 "@jridgewell/source-map": "^0.3.2",
@@ -8361,10 +8361,10 @@
         },
         "packages/crypto": {
             "name": "@iota/crypto.js",
-            "version": "1.9.0-stardust.5",
+            "version": "1.9.0-stardust.6",
             "license": "Apache-2.0",
             "dependencies": {
-                "@iota/util.js": "^1.9.0-stardust.4",
+                "@iota/util.js": "^1.9.0-stardust.5",
                 "big-integer": "^1.6.51"
             },
             "devDependencies": {
@@ -8397,11 +8397,11 @@
         },
         "packages/iota": {
             "name": "@iota/iota.js",
-            "version": "1.9.0-stardust.20",
+            "version": "1.9.0-stardust.24",
             "license": "Apache-2.0",
             "dependencies": {
-                "@iota/crypto.js": "^1.9.0-stardust.5",
-                "@iota/util.js": "^1.9.0-stardust.4",
+                "@iota/crypto.js": "^1.9.0-stardust.6",
+                "@iota/util.js": "^1.9.0-stardust.5",
                 "big-integer": "^1.6.51",
                 "node-fetch": "2.6.7"
             },
@@ -8775,11 +8775,11 @@
         },
         "packages/mqtt": {
             "name": "@iota/mqtt.js",
-            "version": "1.9.0-stardust.12",
+            "version": "1.9.0-stardust.15",
             "license": "Apache-2.0",
             "dependencies": {
-                "@iota/iota.js": "^1.9.0-stardust.16",
-                "@iota/util.js": "^1.9.0-stardust.4",
+                "@iota/iota.js": "^1.9.0-stardust.22",
+                "@iota/util.js": "^1.9.0-stardust.5",
                 "mqtt": "^4.3.5"
             },
             "devDependencies": {
@@ -8789,6 +8789,7 @@
                 "@types/ws": "^8.5.2",
                 "@typescript-eslint/eslint-plugin": "5.14.0",
                 "@typescript-eslint/parser": "^5.14.0",
+                "copyfiles": "^2.4.1",
                 "cross-env": "^7.0.3",
                 "eslint": "^8.10.0",
                 "eslint-plugin-header": "^3.1.1",
@@ -8941,7 +8942,7 @@
         },
         "packages/util": {
             "name": "@iota/util.js",
-            "version": "1.9.0-stardust.4",
+            "version": "1.9.0-stardust.5",
             "license": "Apache-2.0",
             "dependencies": {
                 "big-integer": "^1.6.51"
@@ -8966,74 +8967,12 @@
                 "rollup-plugin-terser": "^7.0.2",
                 "ts-jest": "^27.1.3",
                 "ts-node": "^10.7.0",
-                "typedoc": "^0.22.13",
-                "typedoc-plugin-markdown": "^3.11.14",
+                "typedoc": "^0.23.0",
+                "typedoc-plugin-markdown": "^3.13.3",
                 "typescript": "^4.6.2"
             },
             "engines": {
                 "node": ">=14.0.0"
-            }
-        },
-        "packages/util/node_modules/brace-expansion": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-            "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-            "dev": true,
-            "dependencies": {
-                "balanced-match": "^1.0.0"
-            }
-        },
-        "packages/util/node_modules/glob": {
-            "version": "8.0.3",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-8.0.3.tgz",
-            "integrity": "sha512-ull455NHSHI/Y1FqGaaYFaLGkNMMJbavMrEGFXG/PGrg6y7sutWHUHrz6gy6WEBH6akM1M414dWKCNs+IhKdiQ==",
-            "dev": true,
-            "dependencies": {
-                "fs.realpath": "^1.0.0",
-                "inflight": "^1.0.4",
-                "inherits": "2",
-                "minimatch": "^5.0.1",
-                "once": "^1.3.0"
-            },
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
-        "packages/util/node_modules/minimatch": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.0.tgz",
-            "integrity": "sha512-9TPBGGak4nHfGZsPBohm9AWg6NoT7QTCehS3BIJABslyZbzxfV78QM2Y6+i741OPZIafFAaiiEMh5OyIrJPgtg==",
-            "dev": true,
-            "dependencies": {
-                "brace-expansion": "^2.0.1"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "packages/util/node_modules/typedoc": {
-            "version": "0.22.18",
-            "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.22.18.tgz",
-            "integrity": "sha512-NK9RlLhRUGMvc6Rw5USEYgT4DVAUFk7IF7Q6MYfpJ88KnTZP7EneEa4RcP+tX1auAcz7QT1Iy0bUSZBYYHdoyA==",
-            "dev": true,
-            "dependencies": {
-                "glob": "^8.0.3",
-                "lunr": "^2.3.9",
-                "marked": "^4.0.16",
-                "minimatch": "^5.1.0",
-                "shiki": "^0.10.1"
-            },
-            "bin": {
-                "typedoc": "bin/typedoc"
-            },
-            "engines": {
-                "node": ">= 12.10.0"
-            },
-            "peerDependencies": {
-                "typescript": "4.0.x || 4.1.x || 4.2.x || 4.3.x || 4.4.x || 4.5.x || 4.6.x || 4.7.x"
             }
         }
     },
@@ -9554,7 +9493,7 @@
         "@iota/crypto.js": {
             "version": "file:packages/crypto",
             "requires": {
-                "@iota/util.js": "^1.9.0-stardust.4",
+                "@iota/util.js": "^1.9.0-stardust.5",
                 "@rollup/plugin-commonjs": "^21.0.2",
                 "@rollup/plugin-node-resolve": "^13.1.3",
                 "@types/jest": "^27.4.1",
@@ -9583,8 +9522,8 @@
         "@iota/iota.js": {
             "version": "file:packages/iota",
             "requires": {
-                "@iota/crypto.js": "^1.9.0-stardust.5",
-                "@iota/util.js": "^1.9.0-stardust.4",
+                "@iota/crypto.js": "^1.9.0-stardust.6",
+                "@iota/util.js": "^1.9.0-stardust.5",
                 "@rollup/plugin-commonjs": "^21.0.2",
                 "@rollup/plugin-node-resolve": "^13.1.3",
                 "@types/jest": "^27.4.1",
@@ -9629,14 +9568,15 @@
         "@iota/mqtt.js": {
             "version": "file:packages/mqtt",
             "requires": {
-                "@iota/iota.js": "^1.9.0-stardust.16",
-                "@iota/util.js": "^1.9.0-stardust.4",
+                "@iota/iota.js": "^1.9.0-stardust.22",
+                "@iota/util.js": "^1.9.0-stardust.5",
                 "@rollup/plugin-commonjs": "^21.0.2",
                 "@rollup/plugin-node-resolve": "^13.1.3",
                 "@types/jest": "^27.4.1",
                 "@types/ws": "^8.5.2",
                 "@typescript-eslint/eslint-plugin": "5.14.0",
                 "@typescript-eslint/parser": "^5.14.0",
+                "copyfiles": "^2.4.1",
                 "cross-env": "^7.0.3",
                 "eslint": "^8.10.0",
                 "eslint-plugin-header": "^3.1.1",
@@ -9762,55 +9702,9 @@
                 "rollup-plugin-terser": "^7.0.2",
                 "ts-jest": "^27.1.3",
                 "ts-node": "^10.7.0",
-                "typedoc": "^0.22.13",
-                "typedoc-plugin-markdown": "^3.11.14",
+                "typedoc": "^0.23.0",
+                "typedoc-plugin-markdown": "^3.13.3",
                 "typescript": "^4.6.2"
-            },
-            "dependencies": {
-                "brace-expansion": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-                    "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-                    "dev": true,
-                    "requires": {
-                        "balanced-match": "^1.0.0"
-                    }
-                },
-                "glob": {
-                    "version": "8.0.3",
-                    "resolved": "https://registry.npmjs.org/glob/-/glob-8.0.3.tgz",
-                    "integrity": "sha512-ull455NHSHI/Y1FqGaaYFaLGkNMMJbavMrEGFXG/PGrg6y7sutWHUHrz6gy6WEBH6akM1M414dWKCNs+IhKdiQ==",
-                    "dev": true,
-                    "requires": {
-                        "fs.realpath": "^1.0.0",
-                        "inflight": "^1.0.4",
-                        "inherits": "2",
-                        "minimatch": "^5.0.1",
-                        "once": "^1.3.0"
-                    }
-                },
-                "minimatch": {
-                    "version": "5.1.0",
-                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.0.tgz",
-                    "integrity": "sha512-9TPBGGak4nHfGZsPBohm9AWg6NoT7QTCehS3BIJABslyZbzxfV78QM2Y6+i741OPZIafFAaiiEMh5OyIrJPgtg==",
-                    "dev": true,
-                    "requires": {
-                        "brace-expansion": "^2.0.1"
-                    }
-                },
-                "typedoc": {
-                    "version": "0.22.18",
-                    "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.22.18.tgz",
-                    "integrity": "sha512-NK9RlLhRUGMvc6Rw5USEYgT4DVAUFk7IF7Q6MYfpJ88KnTZP7EneEa4RcP+tX1auAcz7QT1Iy0bUSZBYYHdoyA==",
-                    "dev": true,
-                    "requires": {
-                        "glob": "^8.0.3",
-                        "lunr": "^2.3.9",
-                        "marked": "^4.0.16",
-                        "minimatch": "^5.1.0",
-                        "shiki": "^0.10.1"
-                    }
-                }
             }
         },
         "@istanbuljs/load-nyc-config": {
@@ -15171,9 +15065,9 @@
             }
         },
         "terser": {
-            "version": "5.14.1",
-            "resolved": "https://registry.npmjs.org/terser/-/terser-5.14.1.tgz",
-            "integrity": "sha512-+ahUAE+iheqBTDxXhTisdA8hgvbEG1hHOQ9xmNjeUJSoi6DU/gMrKNcfZjHkyY6Alnuyc+ikYJaxxfHkT3+WuQ==",
+            "version": "5.14.2",
+            "resolved": "https://registry.npmjs.org/terser/-/terser-5.14.2.tgz",
+            "integrity": "sha512-oL0rGeM/WFQCUd0y2QrWxYnq7tfSuKBiqTjRPWrRgB46WD/kiwHwF8T23z78H6Q6kGCuuHcPB+KULHRdxvVGQA==",
             "dev": true,
             "requires": {
                 "@jridgewell/source-map": "^0.3.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@iota/workspaces",
     "description": "IOTA JavaScript Library",
-    "version": "1.9.0-stardust.4",
+    "version": "1.9.0-stardust.5",
     "keywords": [
         "iota"
     ],

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@iota/workspaces",
     "description": "IOTA JavaScript Library",
-    "version": "1.9.0-stardust.5",
+    "version": "1.9.0-stardust.4",
     "keywords": [
         "iota"
     ],

--- a/packages/iota/docs/classes/IndexerPluginClient.md
+++ b/packages/iota/docs/classes/IndexerPluginClient.md
@@ -48,13 +48,13 @@ Find outputs using filter options.
 | :------ | :------ | :------ |
 | `filterOptions?` | `Object` | The options for filtering. |
 | `filterOptions.addressBech32?` | `string` | Filter outputs that are unlockable by the address. |
-| `filterOptions.hasStorageReturnCondition?` | `boolean` | Filter for outputs having a storage return unlock condition. |
-| `filterOptions.storageReturnAddressBech32?` | `string` | Filter for outputs with a certain storage return address. |
-| `filterOptions.hasExpirationCondition?` | `boolean` | Filter for outputs having an expiration unlock condition. |
+| `filterOptions.hasStorageDepositReturn?` | `boolean` | Filter for outputs having a storage deposit return unlock condition. |
+| `filterOptions.storageDepositReturnAddressBech32?` | `string` | Filter for outputs with a certain storage deposit return address. |
+| `filterOptions.hasExpiration?` | `boolean` | Filter for outputs having an expiration unlock condition. |
 | `filterOptions.expirationReturnAddressBech32?` | `string` | Filter for outputs with a certain expiration return address. |
 | `filterOptions.expiresBefore?` | `number` | Filter for outputs that expire before a certain unix time. |
 | `filterOptions.expiresAfter?` | `number` | Filter for outputs that expire after a certain unix time. |
-| `filterOptions.hasTimelockCondition?` | `boolean` | Filter for outputs having a timelock unlock condition. |
+| `filterOptions.hasTimelock?` | `boolean` | Filter for outputs having a timelock unlock condition. |
 | `filterOptions.timelockedBefore?` | `number` | Filter for outputs that are timelocked before a certain unix time. |
 | `filterOptions.timelockedAfter?` | `number` | Filter for outputs that are timelocked after a certain unix time. |
 | `filterOptions.hasNativeTokens?` | `boolean` | Filter for outputs having native tokens. |
@@ -138,13 +138,13 @@ Find nfts using filter options.
 | :------ | :------ | :------ |
 | `filterOptions?` | `Object` | The options for filtering. |
 | `filterOptions.addressBech32?` | `string` | Filter outputs that are unlockable by the address. |
-| `filterOptions.hasStorageReturnCondition?` | `boolean` | Filter for outputs having a storage return unlock condition. |
-| `filterOptions.storageReturnAddressBech32?` | `string` | Filter for outputs with a certain storage return address. |
-| `filterOptions.hasExpirationCondition?` | `boolean` | Filter for outputs having an expiration unlock condition. |
+| `filterOptions.hasStorageDepositReturn?` | `boolean` | Filter for outputs having a storage deposit return unlock condition. |
+| `filterOptions.storageDepositReturnAddressBech32?` | `string` | Filter for outputs with a certain storage deposit return address. |
+| `filterOptions.hasExpiration?` | `boolean` | Filter for outputs having an expiration unlock condition. |
 | `filterOptions.expirationReturnAddressBech32?` | `string` | Filter for outputs with a certain expiration return address. |
 | `filterOptions.expiresBefore?` | `number` | Filter for outputs that expire before a certain unix time. |
 | `filterOptions.expiresAfter?` | `number` | Filter for outputs that expire after a certain unix time. |
-| `filterOptions.hasTimelockCondition?` | `boolean` | Filter for outputs having a timelock unlock condition. |
+| `filterOptions.hasTimelock?` | `boolean` | Filter for outputs having a timelock unlock condition. |
 | `filterOptions.timelockedBefore?` | `number` | Filter for outputs that are timelocked before a certain unix time. |
 | `filterOptions.timelockedAfter?` | `number` | Filter for outputs that are timelocked after a certain unix time. |
 | `filterOptions.hasNativeTokens?` | `boolean` | Filter for outputs having native tokens. |

--- a/packages/iota/docs/classes/IndexerPluginClient.md
+++ b/packages/iota/docs/classes/IndexerPluginClient.md
@@ -10,7 +10,7 @@ Indexer plugin which provides access to the indexer plugin API.
 
 ### Methods
 
-- [outputs](IndexerPluginClient.md#outputs)
+- [basicOutputs](IndexerPluginClient.md#basicoutputs)
 - [aliases](IndexerPluginClient.md#aliases)
 - [alias](IndexerPluginClient.md#alias)
 - [nfts](IndexerPluginClient.md#nfts)
@@ -36,11 +36,11 @@ Create a new instance of IndexerPluginClient.
 
 ## Methods
 
-### outputs
+### basicOutputs
 
-▸ **outputs**(`filterOptions?`): `Promise`<[`IOutputsResponse`](../interfaces/IOutputsResponse.md)\>
+▸ **basicOutputs**(`filterOptions?`): `Promise`<[`IOutputsResponse`](../interfaces/IOutputsResponse.md)\>
 
-Find outputs using filter options.
+Find basic outputs using filter options.
 
 #### Parameters
 
@@ -49,7 +49,7 @@ Find outputs using filter options.
 | `filterOptions?` | `Object` | The options for filtering. |
 | `filterOptions.addressBech32?` | `string` | Filter outputs that are unlockable by the address. |
 | `filterOptions.hasStorageDepositReturn?` | `boolean` | Filter for outputs having a storage deposit return unlock condition. |
-| `filterOptions.storageDepositReturnAddressBech32?` | `string` | Filter for outputs with a certain storage deposit return address. |
+| `filterOptions.storageDepositReturnAddressBech32?` | `string` | Filter for outputs with storage deposit return address. |
 | `filterOptions.hasExpiration?` | `boolean` | Filter for outputs having an expiration unlock condition. |
 | `filterOptions.expirationReturnAddressBech32?` | `string` | Filter for outputs with a certain expiration return address. |
 | `filterOptions.expiresBefore?` | `number` | Filter for outputs that expire before a certain unix time. |
@@ -79,7 +79,7 @@ ___
 
 ▸ **aliases**(`filterOptions?`): `Promise`<[`IOutputsResponse`](../interfaces/IOutputsResponse.md)\>
 
-Find alises using filter options.
+Find alias outputs using filter options.
 
 #### Parameters
 
@@ -130,7 +130,7 @@ ___
 
 ▸ **nfts**(`filterOptions?`): `Promise`<[`IOutputsResponse`](../interfaces/IOutputsResponse.md)\>
 
-Find nfts using filter options.
+Find nft outputs using filter options.
 
 #### Parameters
 
@@ -139,7 +139,7 @@ Find nfts using filter options.
 | `filterOptions?` | `Object` | The options for filtering. |
 | `filterOptions.addressBech32?` | `string` | Filter outputs that are unlockable by the address. |
 | `filterOptions.hasStorageDepositReturn?` | `boolean` | Filter for outputs having a storage deposit return unlock condition. |
-| `filterOptions.storageDepositReturnAddressBech32?` | `string` | Filter for outputs with a certain storage deposit return address. |
+| `filterOptions.storageDepositReturnAddressBech32?` | `string` | Filter for outputs with storage deposit return address. |
 | `filterOptions.hasExpiration?` | `boolean` | Filter for outputs having an expiration unlock condition. |
 | `filterOptions.expirationReturnAddressBech32?` | `string` | Filter for outputs with a certain expiration return address. |
 | `filterOptions.expiresBefore?` | `number` | Filter for outputs that expire before a certain unix time. |
@@ -190,7 +190,7 @@ ___
 
 ▸ **foundries**(`filterOptions?`): `Promise`<[`IOutputsResponse`](../interfaces/IOutputsResponse.md)\>
 
-Find foundries using filter options.
+Find foundry outputs using filter options.
 
 #### Parameters
 

--- a/packages/iota/examples/browser/index.html
+++ b/packages/iota/examples/browser/index.html
@@ -138,7 +138,7 @@
             // not calculated from a Bip32 path, if you were doing a wallet to wallet transfer you can just use send
             // which calculates all the inputs/outputs for you
             const indexerPlugin = new Iota.IndexerPluginClient(client);
-            const genesisAddressOutputs = await indexerPlugin.outputs({ addressBech32: genesisWalletAddressBech32 });
+            const genesisAddressOutputs = await indexerPlugin.basicOutputs({ addressBech32: genesisWalletAddressBech32 });
 
             const inputsWithKeyPairs = [];
 

--- a/packages/iota/examples/mint-native-tokens/src/index.ts
+++ b/packages/iota/examples/mint-native-tokens/src/index.ts
@@ -484,9 +484,9 @@ async function fetchAndWaitForBasicOutput(addressBech32: string, client: lib.Ind
         console.log("\tTry #", tries, ": fetching basic output for address ", addressBech32)
         outputsResponse = await client.outputs({
             addressBech32,
-            hasStorageReturnCondition: false,
-            hasExpirationCondition: false,
-            hasTimelockCondition: false,
+            hasStorageDepositReturn: false,
+            hasExpiration: false,
+            hasTimelock: false,
             hasNativeTokens: false
         });
         if (outputsResponse.items.length == 0) {

--- a/packages/iota/examples/mint-native-tokens/src/index.ts
+++ b/packages/iota/examples/mint-native-tokens/src/index.ts
@@ -482,7 +482,7 @@ async function fetchAndWaitForBasicOutput(addressBech32: string, client: lib.Ind
         }
         tries++;
         console.log("\tTry #", tries, ": fetching basic output for address ", addressBech32)
-        outputsResponse = await client.outputs({
+        outputsResponse = await client.basicOutputs({
             addressBech32,
             hasStorageDepositReturn: false,
             hasExpiration: false,

--- a/packages/iota/examples/mint-nft/src/index.ts
+++ b/packages/iota/examples/mint-nft/src/index.ts
@@ -269,7 +269,7 @@ async function fetchAndWaitForBasicOutput(addressBech32: string, client: Indexer
         if (tries > maxTries){ break; }
         tries++;
         console.log("\tTry #",tries,": fetching basic output for address ", addressBech32);
-        outputsResponse = await client.outputs({
+        outputsResponse = await client.basicOutputs({
             addressBech32: addressBech32,
             hasStorageDepositReturn: false,
             hasExpiration: false,

--- a/packages/iota/examples/mint-nft/src/index.ts
+++ b/packages/iota/examples/mint-nft/src/index.ts
@@ -271,9 +271,9 @@ async function fetchAndWaitForBasicOutput(addressBech32: string, client: Indexer
         console.log("\tTry #",tries,": fetching basic output for address ", addressBech32);
         outputsResponse = await client.outputs({
             addressBech32: addressBech32,
-            hasStorageReturnCondition: false,
-            hasExpirationCondition: false,
-            hasTimelockCondition: false,
+            hasStorageDepositReturn: false,
+            hasExpiration: false,
+            hasTimelock: false,
             hasNativeTokens: false,
         });
         if (outputsResponse.items.length == 0) {

--- a/packages/iota/examples/native-token-tour/src/index.ts
+++ b/packages/iota/examples/native-token-tour/src/index.ts
@@ -726,7 +726,7 @@ function transferNativeTokensWithoutUnlockCondition(consumedOutput: lib.OutputTy
     return txPayload;
 }
 
-// Transfer native tokens with storage return + expiration unlock condition
+// Transfer native tokens with storage deposit return + expiration unlock condition
 function transferNativeTokensWithUnlockCondition(consumedOutput: lib.OutputTypes, consumedOutputId: string, walletAddressHex: string, walletKeyPair: lib.IKeyPair, info: lib.INodeInfo, targetAddress: lib.AddressTypes) {
     // Prepare the input object
     const input = lib.TransactionHelper.inputFromOutputId(consumedOutputId);
@@ -1560,9 +1560,9 @@ async function fetchAndWaitForBasicOutput(addressBech32: string, client: lib.Ind
         console.log(`\tTry #${tries}: fetching basic output for address ${addressBech32}`)
         outputsResponse = await client.outputs({
             addressBech32: addressBech32,
-            hasStorageReturnCondition: false,
-            hasExpirationCondition: false,
-            hasTimelockCondition: false,
+            hasStorageDepositReturn: false,
+            hasExpiration: false,
+            hasTimelock: false,
             hasNativeTokens: false
         });
         if (outputsResponse.items.length == 0) {

--- a/packages/iota/examples/native-token-tour/src/index.ts
+++ b/packages/iota/examples/native-token-tour/src/index.ts
@@ -1558,7 +1558,7 @@ async function fetchAndWaitForBasicOutput(addressBech32: string, client: lib.Ind
         if (tries > maxTries) { break; }
         tries++;
         console.log(`\tTry #${tries}: fetching basic output for address ${addressBech32}`)
-        outputsResponse = await client.outputs({
+        outputsResponse = await client.basicOutputs({
             addressBech32: addressBech32,
             hasStorageDepositReturn: false,
             hasExpiration: false,

--- a/packages/iota/examples/nft-collection/src/index.ts
+++ b/packages/iota/examples/nft-collection/src/index.ts
@@ -22,7 +22,7 @@ In this example we will explore native tokens:
 3. Transfer an NFT from the collection w/o unlock conditions
 4. Transfer an NFT from the collection via:
     - expiration
-    - storage return
+    - storage deposit return
 5. Transfer the collection NFT
 6. new owner mints new NFTs in the collection
 7. Burn the collection NFT (lock collection)
@@ -710,9 +710,9 @@ async function fetchAndWaitForBasicOutput(addressBech32: string, client: lib.Ind
         console.log(`\tTry #${tries}: fetching basic output for address ${addressBech32}`)
         outputsResponse = await client.outputs({
             addressBech32: addressBech32,
-            hasStorageReturnCondition: false,
-            hasExpirationCondition: false,
-            hasTimelockCondition: false,
+            hasStorageDepositReturn: false,
+            hasExpiration: false,
+            hasTimelock: false,
             hasNativeTokens: false,
         });
         if (outputsResponse.items.length == 0) {

--- a/packages/iota/examples/nft-collection/src/index.ts
+++ b/packages/iota/examples/nft-collection/src/index.ts
@@ -708,7 +708,7 @@ async function fetchAndWaitForBasicOutput(addressBech32: string, client: lib.Ind
         if (tries > maxTries) { break }
         tries++;
         console.log(`\tTry #${tries}: fetching basic output for address ${addressBech32}`)
-        outputsResponse = await client.outputs({
+        outputsResponse = await client.basicOutputs({
             addressBech32: addressBech32,
             hasStorageDepositReturn: false,
             hasExpiration: false,

--- a/packages/iota/examples/transaction/src/index.ts
+++ b/packages/iota/examples/transaction/src/index.ts
@@ -81,7 +81,7 @@ async function run() {
     // not calculated from a Bip32 path, if you were doing a wallet to wallet transfer you can just use send
     // which calculates all the inputs/outputs for you
     const indexerPlugin = new IndexerPluginClient(client);
-    // const genesisAddressOutputs = await indexerPlugin.outputs({ addressBech32: genesisWalletAddressBech32 });
+    // const genesisAddressOutputs = await indexerPlugin.basicOutputs({ addressBech32: genesisWalletAddressBech32 });
     const genesisAddressOutputs = await fetchAndWaitForBasicOutputs(genesisWalletAddressBech32, indexerPlugin);
 
     const inputsWithKeyPairs: {
@@ -173,7 +173,7 @@ async function fetchAndWaitForBasicOutputs(addressBech32: string, client: Indexe
         if (tries > maxTries){break}
         tries++;
         console.log("\tTry #",tries,": fetching basic output for address ", addressBech32)
-        outputsResponse = await client.outputs({
+        outputsResponse = await client.basicOutputs({
             addressBech32: addressBech32,
             hasStorageDepositReturn: false,
             hasExpiration: false,

--- a/packages/iota/examples/transaction/src/index.ts
+++ b/packages/iota/examples/transaction/src/index.ts
@@ -175,9 +175,9 @@ async function fetchAndWaitForBasicOutputs(addressBech32: string, client: Indexe
         console.log("\tTry #",tries,": fetching basic output for address ", addressBech32)
         outputsResponse = await client.outputs({
             addressBech32: addressBech32,
-            hasStorageReturnCondition: false,
-            hasExpirationCondition: false,
-            hasTimelockCondition: false,
+            hasStorageDepositReturn: false,
+            hasExpiration: false,
+            hasTimelock: false,
             hasNativeTokens: false,
         });
         if(outputsResponse.items.length == 0){

--- a/packages/iota/examples/transaction/src/simple.ts
+++ b/packages/iota/examples/transaction/src/simple.ts
@@ -233,7 +233,7 @@ async function fetchAndWaitForBasicOutput(addressBech32: string, client: Indexer
         }
         tries++;
         console.log("\tTry #",tries,": fetching basic output for address ", addressBech32);
-        outputsResponse = await client.outputs({
+        outputsResponse = await client.basicOutputs({
             addressBech32: addressBech32,
             hasStorageDepositReturn: false,
             hasExpiration: false,

--- a/packages/iota/examples/transaction/src/simple.ts
+++ b/packages/iota/examples/transaction/src/simple.ts
@@ -235,9 +235,9 @@ async function fetchAndWaitForBasicOutput(addressBech32: string, client: Indexer
         console.log("\tTry #",tries,": fetching basic output for address ", addressBech32);
         outputsResponse = await client.outputs({
             addressBech32: addressBech32,
-            hasStorageReturnCondition: false,
-            hasExpirationCondition: false,
-            hasTimelockCondition: false,
+            hasStorageDepositReturn: false,
+            hasExpiration: false,
+            hasTimelock: false,
             hasNativeTokens: false,
         });
         if (outputsResponse.items.length == 0) {

--- a/packages/iota/package.json
+++ b/packages/iota/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@iota/iota.js",
     "description": "IOTA JavaScript Library",
-    "version": "1.9.0-stardust.24",
+    "version": "1.9.0-stardust.25",
     "keywords": [
         "iota",
         "client"

--- a/packages/iota/src/clients/plugins/indexerPluginClient.ts
+++ b/packages/iota/src/clients/plugins/indexerPluginClient.ts
@@ -37,13 +37,13 @@ export class IndexerPluginClient {
      * Find outputs using filter options.
      * @param filterOptions The options for filtering.
      * @param filterOptions.addressBech32 Filter outputs that are unlockable by the address.
-     * @param filterOptions.hasStorageReturnCondition Filter for outputs having a storage return unlock condition.
-     * @param filterOptions.storageReturnAddressBech32 Filter for outputs with a certain storage return address.
-     * @param filterOptions.hasExpirationCondition Filter for outputs having an expiration unlock condition.
+     * @param filterOptions.hasStorageDepositReturn Filter for outputs having a storage deposit return unlock condition.
+     * @param filterOptions.storageDepositReturnAddressBech32 Filter for outputs with a certain storage deposit return address.
+     * @param filterOptions.hasExpiration Filter for outputs having an expiration unlock condition.
      * @param filterOptions.expirationReturnAddressBech32 Filter for outputs with a certain expiration return address.
      * @param filterOptions.expiresBefore Filter for outputs that expire before a certain unix time.
      * @param filterOptions.expiresAfter Filter for outputs that expire after a certain unix time.
-     * @param filterOptions.hasTimelockCondition Filter for outputs having a timelock unlock condition.
+     * @param filterOptions.hasTimelock Filter for outputs having a timelock unlock condition.
      * @param filterOptions.timelockedBefore Filter for outputs that are timelocked before a certain unix time.
      * @param filterOptions.timelockedAfter Filter for outputs that are timelocked after a certain unix time.
      * @param filterOptions.hasNativeTokens Filter for outputs having native tokens.
@@ -59,13 +59,13 @@ export class IndexerPluginClient {
      */
     public async outputs(filterOptions?: {
         addressBech32?: string;
-        hasStorageReturnCondition?: boolean;
-        storageReturnAddressBech32?: string;
-        hasExpirationCondition?: boolean;
+        hasStorageDepositReturn?: boolean;
+        storageDepositReturnAddressBech32?: string;
+        hasExpiration?: boolean;
         expirationReturnAddressBech32?: string;
         expiresBefore?: number;
         expiresAfter?: number;
-        hasTimelockCondition?: boolean;
+        hasTimelock?: boolean;
         timelockedBefore?: number;
         timelockedAfter?: number;
         hasNativeTokens?: boolean;
@@ -83,14 +83,14 @@ export class IndexerPluginClient {
             if (filterOptions.addressBech32 !== undefined) {
                 queryParams.push(`address=${filterOptions.addressBech32}`);
             }
-            if (filterOptions.hasStorageReturnCondition !== undefined) {
-                queryParams.push(`hasStorageReturnCondition=${filterOptions.hasStorageReturnCondition}`);
+            if (filterOptions.hasStorageDepositReturn !== undefined) {
+                queryParams.push(`hasStorageDepositReturn=${filterOptions.hasStorageDepositReturn}`);
             }
-            if (filterOptions.storageReturnAddressBech32 !== undefined) {
-                queryParams.push(`storageReturnAddress=${filterOptions.storageReturnAddressBech32}`);
+            if (filterOptions.storageDepositReturnAddressBech32 !== undefined) {
+                queryParams.push(`storageDepositReturnAddress=${filterOptions.storageDepositReturnAddressBech32}`);
             }
-            if (filterOptions.hasExpirationCondition !== undefined) {
-                queryParams.push(`hasExpirationCondition=${filterOptions.hasExpirationCondition}`);
+            if (filterOptions.hasExpiration !== undefined) {
+                queryParams.push(`hasExpiration=${filterOptions.hasExpiration}`);
             }
             if (filterOptions.expirationReturnAddressBech32 !== undefined) {
                 queryParams.push(`expirationReturnAddress=${filterOptions.expirationReturnAddressBech32}`);
@@ -101,8 +101,8 @@ export class IndexerPluginClient {
             if (filterOptions.expiresAfter !== undefined) {
                 queryParams.push(`expiresAfter=${filterOptions.expiresAfter}`);
             }
-            if (filterOptions.hasTimelockCondition !== undefined) {
-                queryParams.push(`hasTimelockCondition=${filterOptions.hasTimelockCondition}`);
+            if (filterOptions.hasTimelock !== undefined) {
+                queryParams.push(`hasTimelock=${filterOptions.hasTimelock}`);
             }
             if (filterOptions.timelockedBefore !== undefined) {
                 queryParams.push(`timelockedBefore=${filterOptions.timelockedBefore}`);
@@ -239,13 +239,13 @@ export class IndexerPluginClient {
      * Find nfts using filter options.
      * @param filterOptions The options for filtering.
      * @param filterOptions.addressBech32 Filter outputs that are unlockable by the address.
-     * @param filterOptions.hasStorageReturnCondition Filter for outputs having a storage return unlock condition.
-     * @param filterOptions.storageReturnAddressBech32 Filter for outputs with a certain storage return address.
-     * @param filterOptions.hasExpirationCondition Filter for outputs having an expiration unlock condition.
+     * @param filterOptions.hasStorageDepositReturn Filter for outputs having a storage deposit return unlock condition.
+     * @param filterOptions.storageDepositReturnAddressBech32 Filter for outputs with a certain storage deposit return address.
+     * @param filterOptions.hasExpiration Filter for outputs having an expiration unlock condition.
      * @param filterOptions.expirationReturnAddressBech32 Filter for outputs with a certain expiration return address.
      * @param filterOptions.expiresBefore Filter for outputs that expire before a certain unix time.
      * @param filterOptions.expiresAfter Filter for outputs that expire after a certain unix time.
-     * @param filterOptions.hasTimelockCondition Filter for outputs having a timelock unlock condition.
+     * @param filterOptions.hasTimelock Filter for outputs having a timelock unlock condition.
      * @param filterOptions.timelockedBefore Filter for outputs that are timelocked before a certain unix time.
      * @param filterOptions.timelockedAfter Filter for outputs that are timelocked after a certain unix time.
      * @param filterOptions.hasNativeTokens Filter for outputs having native tokens.
@@ -262,13 +262,13 @@ export class IndexerPluginClient {
      */
     public async nfts(filterOptions?: {
         addressBech32?: string;
-        hasStorageReturnCondition?: boolean;
-        storageReturnAddressBech32?: string;
-        hasExpirationCondition?: boolean;
+        hasStorageDepositReturn?: boolean;
+        storageDepositReturnAddressBech32?: string;
+        hasExpiration?: boolean;
         expirationReturnAddressBech32?: string;
         expiresBefore?: number;
         expiresAfter?: number;
-        hasTimelockCondition?: boolean;
+        hasTimelock?: boolean;
         timelockedBefore?: number;
         timelockedAfter?: number;
         hasNativeTokens?: boolean;
@@ -287,14 +287,14 @@ export class IndexerPluginClient {
             if (filterOptions.addressBech32 !== undefined) {
                 queryParams.push(`address=${filterOptions.addressBech32}`);
             }
-            if (filterOptions.hasStorageReturnCondition !== undefined) {
-                queryParams.push(`hasStorageReturnCondition=${filterOptions.hasStorageReturnCondition}`);
+            if (filterOptions.hasStorageDepositReturn !== undefined) {
+                queryParams.push(`hasStorageDepositReturn=${filterOptions.hasStorageDepositReturn}`);
             }
-            if (filterOptions.storageReturnAddressBech32 !== undefined) {
-                queryParams.push(`storageReturnAddress=${filterOptions.storageReturnAddressBech32}`);
+            if (filterOptions.storageDepositReturnAddressBech32 !== undefined) {
+                queryParams.push(`storageDepositReturnAddress=${filterOptions.storageDepositReturnAddressBech32}`);
             }
-            if (filterOptions.hasExpirationCondition !== undefined) {
-                queryParams.push(`hasExpirationCondition=${filterOptions.hasExpirationCondition}`);
+            if (filterOptions.hasExpiration !== undefined) {
+                queryParams.push(`hasExpiration=${filterOptions.hasExpiration}`);
             }
             if (filterOptions.expirationReturnAddressBech32 !== undefined) {
                 queryParams.push(`expirationReturnAddress=${filterOptions.expirationReturnAddressBech32}`);
@@ -305,8 +305,8 @@ export class IndexerPluginClient {
             if (filterOptions.expiresAfter !== undefined) {
                 queryParams.push(`expiresAfter=${filterOptions.expiresAfter}`);
             }
-            if (filterOptions.hasTimelockCondition !== undefined) {
-                queryParams.push(`hasTimelockCondition=${filterOptions.hasTimelockCondition}`);
+            if (filterOptions.hasTimelock !== undefined) {
+                queryParams.push(`hasTimelock=${filterOptions.hasTimelock}`);
             }
             if (filterOptions.timelockedBefore !== undefined) {
                 queryParams.push(`timelockedBefore=${filterOptions.timelockedBefore}`);

--- a/packages/iota/src/clients/plugins/indexerPluginClient.ts
+++ b/packages/iota/src/clients/plugins/indexerPluginClient.ts
@@ -38,7 +38,7 @@ export class IndexerPluginClient {
      * @param filterOptions The options for filtering.
      * @param filterOptions.addressBech32 Filter outputs that are unlockable by the address.
      * @param filterOptions.hasStorageDepositReturn Filter for outputs having a storage deposit return unlock condition.
-     * @param filterOptions.storageDepositReturnAddressBech32 Filter for outputs with a certain storage deposit return address.
+     * @param filterOptions.storageDepositReturnAddressBech32 Filter for outputs with storage deposit return address.
      * @param filterOptions.hasExpiration Filter for outputs having an expiration unlock condition.
      * @param filterOptions.expirationReturnAddressBech32 Filter for outputs with a certain expiration return address.
      * @param filterOptions.expiresBefore Filter for outputs that expire before a certain unix time.
@@ -240,7 +240,7 @@ export class IndexerPluginClient {
      * @param filterOptions The options for filtering.
      * @param filterOptions.addressBech32 Filter outputs that are unlockable by the address.
      * @param filterOptions.hasStorageDepositReturn Filter for outputs having a storage deposit return unlock condition.
-     * @param filterOptions.storageDepositReturnAddressBech32 Filter for outputs with a certain storage deposit return address.
+     * @param filterOptions.storageDepositReturnAddressBech32 Filter for outputs with storage deposit return address.
      * @param filterOptions.hasExpiration Filter for outputs having an expiration unlock condition.
      * @param filterOptions.expirationReturnAddressBech32 Filter for outputs with a certain expiration return address.
      * @param filterOptions.expiresBefore Filter for outputs that expire before a certain unix time.

--- a/packages/iota/src/clients/plugins/indexerPluginClient.ts
+++ b/packages/iota/src/clients/plugins/indexerPluginClient.ts
@@ -34,7 +34,7 @@ export class IndexerPluginClient {
     }
 
     /**
-     * Find outputs using filter options.
+     * Find basic outputs using filter options.
      * @param filterOptions The options for filtering.
      * @param filterOptions.addressBech32 Filter outputs that are unlockable by the address.
      * @param filterOptions.hasStorageDepositReturn Filter for outputs having a storage deposit return unlock condition.
@@ -57,7 +57,7 @@ export class IndexerPluginClient {
      * @param filterOptions.cursor Request the items from the given cursor, returned from a previous request.
      * @returns The outputs with the requested filters.
      */
-    public async outputs(filterOptions?: {
+    public async basicOutputs(filterOptions?: {
         addressBech32?: string;
         hasStorageDepositReturn?: boolean;
         storageDepositReturnAddressBech32?: string;
@@ -147,7 +147,7 @@ export class IndexerPluginClient {
     }
 
     /**
-     * Find alises using filter options.
+     * Find alias outputs using filter options.
      * @param filterOptions The options for filtering.
      * @param filterOptions.stateControllerBech32 Filter for a certain state controller address.
      * @param filterOptions.governorBech32 Filter for a certain governance controller address.
@@ -236,7 +236,7 @@ export class IndexerPluginClient {
     }
 
     /**
-     * Find nfts using filter options.
+     * Find nft outputs using filter options.
      * @param filterOptions The options for filtering.
      * @param filterOptions.addressBech32 Filter outputs that are unlockable by the address.
      * @param filterOptions.hasStorageDepositReturn Filter for outputs having a storage deposit return unlock condition.
@@ -370,7 +370,7 @@ export class IndexerPluginClient {
     }
 
     /**
-     * Find foundries using filter options.
+     * Find foundry outputs using filter options.
      * @param filterOptions The options for filtering.
      * @param filterOptions.aliasAddressBech32 Filter outputs that are unlockable by the address.
      * @param filterOptions.hasNativeTokens Filter for outputs having native tokens.

--- a/packages/iota/src/highLevel/addressBalance.ts
+++ b/packages/iota/src/highLevel/addressBalance.ts
@@ -32,7 +32,7 @@ export async function addressBalance(
     let response;
     let cursor;
     do {
-        response = await indexerPluginClient.outputs({ addressBech32, cursor });
+        response = await indexerPluginClient.basicOutputs({ addressBech32, cursor });
 
         for (const outputId of response.items) {
             const output = await localClient.output(outputId);

--- a/packages/iota/src/highLevel/send.ts
+++ b/packages/iota/src/highLevel/send.ts
@@ -307,7 +307,7 @@ export async function calculateInputs<T>(
         const addressBytes = ed25519Address.toAddress();
 
         const indexerPlugin = new IndexerPluginClient(client);
-        const addressOutputIds = await indexerPlugin.outputs(
+        const addressOutputIds = await indexerPlugin.basicOutputs(
             { addressBech32: Bech32Helper.toBech32(ED25519_ADDRESS_TYPE, addressBytes, protocolInfo.bech32Hrp) });
 
         if (addressOutputIds.items.length === 0) {


### PR DESCRIPTION
function `outputs` => `basicOutputs`

`hasStorageReturnCondition` => `hasStorageDepositReturn`
`storageReturnAddress` => `storageDepositReturnAddress`
`hasExpirationCondition` => `hasExpiration`
`hasTimelockCondition` => `hasTimelock`
