### PR TITLE
Fix: Add balance from expired outputs in total balance

### DIFF
--- a/packages/iota/src/highLevel/addressBalance.ts
+++ b/packages/iota/src/highLevel/addressBalance.ts
@@ -32,6 +32,7 @@ export async function addressBalance(
     let response;
     let expirationResponse;
     let cursor;
+    let expirationCursor;
     do {
         response = await indexerPluginClient.outputs({ addressBech32, cursor });
 
@@ -56,7 +57,9 @@ export async function addressBalance(
 
     do {
         expirationResponse = await indexerPluginClient.outputs({
-            expirationReturnAddressBech32: addressBech32, expiresBefore: Math.floor(Date.now() / 1000), cursor
+            expirationReturnAddressBech32: addressBech32,
+            expiresBefore: Math.floor(Date.now() / 1000),
+            cursor: expirationCursor
         });
 
         for (const outputId of expirationResponse.items) {
@@ -66,8 +69,8 @@ export async function addressBalance(
                 total = total.plus(output.output.amount);
             }
         }
-        cursor = response.cursor;
-    } while (cursor && expirationResponse.items.length > 0);
+        expirationCursor = expirationResponse.cursor;
+    } while (expirationCursor && expirationResponse.items.length > 0);
 
     return {
         balance: total,

--- a/packages/iota/src/highLevel/addressBalance.ts
+++ b/packages/iota/src/highLevel/addressBalance.ts
@@ -63,7 +63,7 @@ export async function addressBalance(
         });
 
         for (const outputId of expirationResponse.items) {
-            const output = await localClient.output(String(outputId);
+            const output = await localClient.output(outputId);
 
             if (!output.metadata.isSpent) {
                 total = total.plus(output.output.amount);

--- a/packages/iota/src/highLevel/addressBalance.ts
+++ b/packages/iota/src/highLevel/addressBalance.ts
@@ -55,7 +55,7 @@ export async function addressBalance(
     } while (cursor && response.items.length > 0);
 
     do {
-        expirationResponse = await indexerPluginClient.outputs({
+        expirationResponse = await indexerPluginClient.basicOutputs({
             expirationReturnAddressBech32: addressBech32, expiresBefore: Math.floor(Date.now() / 1000), cursor
         });
 

--- a/packages/iota/src/highLevel/addressBalance.ts
+++ b/packages/iota/src/highLevel/addressBalance.ts
@@ -56,14 +56,14 @@ export async function addressBalance(
     } while (cursor && response.items.length > 0);
 
     do {
-        expirationResponse = await indexerPluginClient.outputs({
+        expirationResponse = await indexerPluginClient.basicOutputs({
             expirationReturnAddressBech32: addressBech32,
             expiresBefore: Math.floor(Date.now() / 1000),
             cursor: expirationCursor
         });
 
         for (const outputId of expirationResponse.items) {
-            const output = await localClient.output(outputId);
+            const output = await localClient.output(String(outputId);
 
             if (!output.metadata.isSpent) {
                 total = total.plus(output.output.amount);


### PR DESCRIPTION
# Description of change

- Updated `addressBalance` function to also add expired outputs amount to the balance of the return address.

fixes https://github.com/iotaledger/iota.js/issues/955

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## Change checklist

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [] I have added tests that prove my fix is effective or that my feature works
- [] New and existing unit tests pass locally with my changes
