### PR TITLE
fix URL to shimmer testnet

### DIFF
--- a/packages/iota/examples/simple/src/index.ts
+++ b/packages/iota/examples/simple/src/index.ts
@@ -13,7 +13,7 @@ import {
 import { Converter, ReadStream } from "@iota/util.js";
 import { NeonPowProvider } from "@iota/pow-neon.js";
 
-const API_ENDPOINT = "https://api.alphanet.iotaledger.net/";
+const API_ENDPOINT = "https://api.testnet.shimmer.network/";
 
 // If running the node locally
 // const API_ENDPOINT = "http://localhost:14265/";


### PR DESCRIPTION
# Description of change

This HowTo https://wiki.iota.org/iotajs/how_tos/simple connects to an older node. This PR changed it to the shimmer testnet node