### PR TITLE
Fix: Pow-neon add missing _index_.node file to dist

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9019,7 +9019,7 @@
         },
         "packages/pow-neon": {
             "name": "@iota/pow-neon.js",
-            "version": "2.0.0-rc.1",
+            "version": "2.0.0-rc.2",
             "hasInstallScript": true,
             "license": "Apache-2.0",
             "dependencies": {

--- a/packages/pow-neon/CHANGELOG.md
+++ b/packages/pow-neon/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.0.0-rc.2
+
+* Fix for missing node index file
+
 ## 2.0.0-rc.1
 
 * Stardust release candidate

--- a/packages/pow-neon/README.md
+++ b/packages/pow-neon/README.md
@@ -9,7 +9,7 @@ You will need the rust toolchain installed so that the native module can be buil
 ## Install
 
 ```shell
-npm install @iota/pow-neon.js@2.0.0-rc.1
+npm install @iota/pow-neon.js@2.0.0-rc.2
 
 ```
 ## Usage

--- a/packages/pow-neon/copy-dist.js
+++ b/packages/pow-neon/copy-dist.js
@@ -3,4 +3,4 @@ const fs = require("fs");
 try {
     fs.mkdirSync("./dist/native", { recursive: true });
 } catch (err) {}
-fs.copyFileSync("./native/index.node", "./dist/native/index.node");
+fs.copyFileSync("./native/index.node", "./dist/native/_index_.node");

--- a/packages/pow-neon/package.json
+++ b/packages/pow-neon/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@iota/pow-neon.js",
     "description": "IOTA JavaScript Library for Performing Multi-Threaded PoW on NodeJS",
-    "version": "2.0.0-rc.1",
+    "version": "2.0.0-rc.2",
     "keywords": [
         "iota",
         "pow"


### PR DESCRIPTION
# Description of change

- Change file name from index.node to _index_.node during copying from native folder

- release v2.0.0-rc2

fixes #996.

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## Change checklist

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
