### PR TITLE
enhancement: added support for different coin types in address genera…

### DIFF
--- a/packages/iota/docs/api.md
+++ b/packages/iota/docs/api.md
@@ -1770,17 +1770,18 @@ ___
 
 ### generateBip44Path
 
-▸ **generateBip44Path**(`accountIndex`, `addressIndex`, `isInternal`): `Bip32Path`
+▸ **generateBip44Path**(`accountIndex`, `addressIndex`, `isInternal`, `coinType`): `Bip32Path`
 
 Generate a bip44 path based on all its parts.
 
 #### Parameters
 
-| Name | Type | Description |
-| :------ | :------ | :------ |
-| `accountIndex` | `number` | The account index. |
-| `addressIndex` | `number` | The address index. |
-| `isInternal` | `boolean` | Is this an internal address. |
+| Name           | Type       | Description                           |
+|:---------------|:-----------|:--------------------------------------|
+| `accountIndex` | `number`   | The account index.                    |
+| `addressIndex` | `number`   | The address index.                    |
+| `isInternal`   | `boolean`  | Is this an internal address.          |
+| `coinType`     | `number`   | The coin type, default is 4218 (IOTA) |
 
 #### Returns
 
@@ -1792,15 +1793,16 @@ ___
 
 ### generateBip44Address
 
-▸ **generateBip44Address**(`generatorState`): `string`
+▸ **generateBip44Address**(`generatorState`, `coinType`): `string`
 
 Generate addresses based on the account indexing style.
 
 #### Parameters
 
-| Name | Type | Description |
-| :------ | :------ | :------ |
-| `generatorState` | [`IBip44GeneratorState`](interfaces/IBip44GeneratorState.md) | The address state. |
+| Name             | Type                                                         | Description                           |
+|:-----------------|:-------------------------------------------------------------|:--------------------------------------|
+| `generatorState` | [`IBip44GeneratorState`](interfaces/IBip44GeneratorState.md) | The address state.                    |
+| `coinType`       | `number`                                                     | The coin type, default is 4218 (IOTA) |
 
 #### Returns
 

--- a/packages/iota/src/highLevel/addresses.ts
+++ b/packages/iota/src/highLevel/addresses.ts
@@ -3,17 +3,24 @@
 import { Bip32Path } from "@iota/crypto.js";
 import type { IBip44GeneratorState } from "../models/IBip44GeneratorState";
 
-export const IOTA_BIP44_BASE_PATH: string = "m/44'/4218'";
+export const COIN_TYPE_IOTA = 4218;
+export const COIN_TYPE_SHIMMER = 4219;
 
 /**
  * Generate a bip44 path based on all its parts.
  * @param accountIndex The account index.
  * @param addressIndex The address index.
  * @param isInternal Is this an internal address.
+ * @param coinType The coin type, default is the IOTA coin type.
  * @returns The generated address.
  */
-export function generateBip44Path(accountIndex: number, addressIndex: number, isInternal: boolean): Bip32Path {
-    const bip32Path = new Bip32Path(IOTA_BIP44_BASE_PATH);
+export function generateBip44Path(
+    accountIndex: number,
+    addressIndex: number,
+    isInternal: boolean,
+    coinType = COIN_TYPE_IOTA
+): Bip32Path {
+    const bip32Path = new Bip32Path(generateBip44BasePath(coinType));
 
     bip32Path.pushHardened(accountIndex);
     bip32Path.pushHardened(isInternal ? 1 : 0);
@@ -28,10 +35,11 @@ export function generateBip44Path(accountIndex: number, addressIndex: number, is
  * @param generatorState.accountIndex The index of the account to calculate.
  * @param generatorState.addressIndex The index of the address to calculate.
  * @param generatorState.isInternal Are we generating an internal address.
+ * @param coinType The coin type, default is the IOTA coin type.
  * @returns The key pair for the address.
  */
-export function generateBip44Address(generatorState: IBip44GeneratorState): string {
-    const path = new Bip32Path(IOTA_BIP44_BASE_PATH);
+export function generateBip44Address(generatorState: IBip44GeneratorState, coinType = COIN_TYPE_IOTA): string {
+    const path = new Bip32Path(generateBip44BasePath(coinType));
 
     path.pushHardened(generatorState.accountIndex);
     path.pushHardened(generatorState.isInternal ? 1 : 0);
@@ -47,4 +55,13 @@ export function generateBip44Address(generatorState: IBip44GeneratorState): stri
     }
 
     return path.toString();
+}
+
+/**
+ * Create a bip44 base path for the provided coin type.
+ * @param coinType The coin type.
+ * @returns The bip44 address base path.
+ */
+function generateBip44BasePath(coinType: number) {
+    return `m/44'/${coinType}'`;
 }

--- a/packages/iota/test/highLevel/addresses.spec.ts
+++ b/packages/iota/test/highLevel/addresses.spec.ts
@@ -1,6 +1,6 @@
 // Copyright 2020 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
-import { generateBip44Path, generateBip44Address } from "../../src/highLevel/addresses";
+import { generateBip44Path, generateBip44Address, COIN_TYPE_SHIMMER } from "../../src/highLevel/addresses";
 
 describe("Addresses", () => {
     test("can generate an address with generateBip44Path with external index", () => {
@@ -24,6 +24,19 @@ describe("Addresses", () => {
         expect(parts[0]).toEqual("m");
         expect(parts[1]).toEqual("44'");
         expect(parts[2]).toEqual("4218'");
+        expect(parts[3]).toEqual("0'");
+        expect(parts[4]).toEqual("1'");
+        expect(parts[5]).toEqual("0'");
+    });
+
+    test("can generate an address with generateBip44Path with custom coin type", () => {
+        const path = generateBip44Path(0, 0, true, COIN_TYPE_SHIMMER);
+
+        const parts = path.toString().split("/");
+
+        expect(parts[0]).toEqual("m");
+        expect(parts[1]).toEqual("44'");
+        expect(parts[2]).toEqual(`${COIN_TYPE_SHIMMER}'`);
         expect(parts[3]).toEqual("0'");
         expect(parts[4]).toEqual("1'");
         expect(parts[5]).toEqual("0'");
@@ -69,5 +82,26 @@ describe("Addresses", () => {
         expect(addresses[3]).toEqual("m/44'/4218'/0'/0'/2'");
         expect(addresses[4]).toEqual("m/44'/4218'/0'/1'/2'");
         expect(addresses[5]).toEqual("m/44'/4218'/0'/0'/3'");
+    });
+
+    test("can generate multiple addresses with generator and custom coin type", () => {
+        const generatorState = {
+            accountIndex: 0,
+            isInternal: false,
+            addressIndex: 0
+        };
+
+        const addresses = [];
+
+        for (let i = 0; i < 6; i++) {
+            addresses.push(generateBip44Address(generatorState, COIN_TYPE_SHIMMER));
+        }
+
+        expect(addresses[0]).toEqual(`m/44'/${COIN_TYPE_SHIMMER}'/0'/0'/0'`);
+        expect(addresses[1]).toEqual(`m/44'/${COIN_TYPE_SHIMMER}'/0'/1'/0'`);
+        expect(addresses[2]).toEqual(`m/44'/${COIN_TYPE_SHIMMER}'/0'/0'/1'`);
+        expect(addresses[3]).toEqual(`m/44'/${COIN_TYPE_SHIMMER}'/0'/1'/1'`);
+        expect(addresses[4]).toEqual(`m/44'/${COIN_TYPE_SHIMMER}'/0'/0'/2'`);
+        expect(addresses[5]).toEqual(`m/44'/${COIN_TYPE_SHIMMER}'/0'/1'/2'`);
     });
 });


### PR DESCRIPTION
Added the option to set the coin type for address generation manually as described by Thoralf in https://github.com/iotaledger/iota.js/issues/1024

Resolves https://github.com/iotaledger/iota.js/issues/1024

# Description of change

Added coin type as optional parameter. Default is IOTA so that no breaking changes of the signature have been made. `fixes #1024`.

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Writing unit test for the affected functionality

## Change checklist

- [X] My code follows the contribution guidelines for this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
