### PR TITLE
Fix: Remove unused constant from address example

### DIFF
--- a/packages/iota/docs/api.md
+++ b/packages/iota/docs/api.md
@@ -3360,18 +3360,18 @@ ___
 
 ### generateBip44Path
 
-▸ **generateBip44Path**(`accountIndex`, `addressIndex`, `isInternal`, `coinType`): `Bip32Path`
+▸ **generateBip44Path**(`accountIndex`, `addressIndex`, `isInternal`, `coinType?`): `Bip32Path`
 
 Generate a bip44 path based on all its parts.
 
 #### Parameters
 
-| Name           | Type       | Description                           |
-|:---------------|:-----------|:--------------------------------------|
-| `accountIndex` | `number`   | The account index.                    |
-| `addressIndex` | `number`   | The address index.                    |
-| `isInternal`   | `boolean`  | Is this an internal address.          |
-| `coinType`     | `number`   | The coin type, default is 4218 (IOTA) |
+| Name | Type | Default value | Description |
+| :------ | :------ | :------ | :------ |
+| `accountIndex` | `number` | `undefined` | The account index. |
+| `addressIndex` | `number` | `undefined` | The address index. |
+| `isInternal` | `boolean` | `undefined` | Is this an internal address. |
+| `coinType` | `number` | `COIN_TYPE_IOTA` | The coin type, default is the IOTA coin type. |
 
 #### Returns
 
@@ -3383,16 +3383,16 @@ ___
 
 ### generateBip44Address
 
-▸ **generateBip44Address**(`generatorState`, `coinType`): `string`
+▸ **generateBip44Address**(`generatorState`, `coinType?`): `string`
 
 Generate addresses based on the account indexing style.
 
 #### Parameters
 
-| Name             | Type                                                         | Description                           |
-|:-----------------|:-------------------------------------------------------------|:--------------------------------------|
-| `generatorState` | [`IBip44GeneratorState`](interfaces/IBip44GeneratorState.md) | The address state.                    |
-| `coinType`       | `number`                                                     | The coin type, default is 4218 (IOTA) |
+| Name | Type | Default value | Description |
+| :------ | :------ | :------ | :------ |
+| `generatorState` | [`IBip44GeneratorState`](interfaces/IBip44GeneratorState.md) | `undefined` | The address state. |
+| `coinType` | `number` | `COIN_TYPE_IOTA` | The coin type, default is the IOTA coin type. |
 
 #### Returns
 

--- a/packages/iota/examples/address/src/index.ts
+++ b/packages/iota/examples/address/src/index.ts
@@ -6,7 +6,7 @@ import {
     Ed25519Seed,
     ED25519_ADDRESS_TYPE,
     generateBip44Address,
-    IOTA_BIP44_BASE_PATH,
+    COIN_TYPE_IOTA,
     SingleNodeClient
 } from "@iota/iota.js";
 
@@ -61,7 +61,8 @@ async function run() {
     console.log();
 
     // You can perform the same process as the generator manually as follows.
-    const basePath = new Bip32Path(IOTA_BIP44_BASE_PATH);
+    const basePath = new Bip32Path(`m/44'/${COIN_TYPE_IOTA}'`);
+
     const accountIndex = 0;
     let isInternal = false;
     let addressIndex = 0;


### PR DESCRIPTION
# Description of change

Remove unused constant `IOTA_BIP44_BASE_PATH` from iota package address example.

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## Change checklist

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
