### PR TITLE
Fix(dist): Import issue for Pow packages

### DIFF
--- a/packages/pow-browser/package.json
+++ b/packages/pow-browser/package.json
@@ -58,7 +58,6 @@
         "typescript": "^4.6.2"
     },
     "main": "dist/pow-browser.js",
-    "module": "es/pow-browser.js",
     "typings": "typings/index.d.ts",
     "files": [
         "dist",

--- a/packages/pow-neon/package.json
+++ b/packages/pow-neon/package.json
@@ -62,7 +62,6 @@
         "typescript": "^4.8.3"
     },
     "main": "dist/pow-neon.js",
-    "module": "es/pow-neon.js",
     "typings": "typings/index.d.ts",
     "files": [
         "dist/pow-neon.js",

--- a/packages/pow-node/package.json
+++ b/packages/pow-node/package.json
@@ -57,7 +57,6 @@
         "typescript": "^4.8.3"
     },
     "main": "dist/pow-node.js",
-    "module": "es/pow-node.js",
     "typings": "typings/index.d.ts",
     "files": [
         "dist",

--- a/packages/pow-wasm/package.json
+++ b/packages/pow-wasm/package.json
@@ -58,7 +58,6 @@
         "typescript": "^4.8.3"
     },
     "main": "dist/pow-wasm.js",
-    "module": "es/pow-wasm.js",
     "typings": "typings/index.d.ts",
     "files": [
         "dist",


### PR DESCRIPTION
# Description of change

Removes the 'module' field from pow-* packages as it is useless and it causes an import issue with vite bundler.

The module field is not mandatory, and currently is pointing to a folder/file which is not even included in the published npm lib. The es folder is used as an intermediate step in building the `dist` (with rollup) folder which is published.

Resolves https://github.com/iotaledger/iota.js/issues/1148

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Small vite example app + iota.js Pow examples run
