### PR TITLE
Docs - Update testnet network name and id

### DIFF
--- a/documentation/docs/tutorials/value-transactions/07-query-output-details.md
+++ b/documentation/docs/tutorials/value-transactions/07-query-output-details.md
@@ -41,8 +41,8 @@ you [generated the public address](05-public-addresses.md):
 
 ```json
 {
-  "networkName": "testnet",
-  "networkId": "8342982141227064571",
+  "networkName": "testnet-1",
+  "networkId": "1856588631910923207",
   "bech32Hrp": "rms",
   "minPowScore": 1500
 }


### PR DESCRIPTION
# Description of change

Updated testnet `networkName` to `testnet-1` and `networkId` to  `1856588631910923207` in expected outputs.

## Type of change

- Documentation Fix

## Related Issues

partially addresses https://github.com/iotaledger/guild-devx/issues/8

## How the change has been tested

Wiki was built locally.

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have made corresponding changes to the documentation
