### PR TITLE
Fix: Reading unsigned int32

### DIFF
--- a/packages/util/src/utils/readStream.ts
+++ b/packages/util/src/utils/readStream.ts
@@ -162,10 +162,7 @@ export class ReadStream {
             throw new Error(`${name} length 4 exceeds the remaining data ${this.unused()}`);
         }
 
-        const val =
-            this._storage[this._readIndex] |
-            (this._storage[this._readIndex + 1] * 0x100) |
-            (this._storage[this._readIndex + 2] * 0x10000 + this._storage[this._readIndex + 3] * 0x1000000);
+        const val = Number(BigIntHelper.read4(this._storage, this._readIndex));
 
         if (moveIndex) {
             this._readIndex += 4;


### PR DESCRIPTION
# Description of change

The `ReadStream.readUInt32` method has been updated to read uint32 as an unsigned integer instead of being read as a signed integer, which was the previous behavior.
fixes #1149 .

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## Change checklist

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
